### PR TITLE
feat(fhir): implement FHIR Subscription Manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,8 @@ if(BRIDGE_BUILD_FHIR)
         src/fhir/patient_resource.cpp
         src/fhir/service_request_resource.cpp
         src/fhir/imaging_study_resource.cpp
+        src/fhir/subscription_resource.cpp
+        src/fhir/subscription_manager.cpp
         src/mapping/fhir_dicom_mapper.cpp
     )
     list(APPEND PACS_BRIDGE_HEADERS
@@ -292,6 +294,8 @@ if(BRIDGE_BUILD_FHIR)
         include/pacs/bridge/fhir/patient_resource.h
         include/pacs/bridge/fhir/service_request_resource.h
         include/pacs/bridge/fhir/imaging_study_resource.h
+        include/pacs/bridge/fhir/subscription_resource.h
+        include/pacs/bridge/fhir/subscription_manager.h
         include/pacs/bridge/mapping/fhir_dicom_mapper.h
     )
 endif()

--- a/include/pacs/bridge/fhir/fhir_types.h
+++ b/include/pacs/bridge/fhir/fhir_types.h
@@ -186,6 +186,7 @@ enum class resource_type {
     practitioner,
     organization,
     endpoint,
+    subscription,
     operation_outcome,
     bundle,
     capability_statement,
@@ -205,6 +206,7 @@ enum class resource_type {
         case resource_type::practitioner: return "Practitioner";
         case resource_type::organization: return "Organization";
         case resource_type::endpoint: return "Endpoint";
+        case resource_type::subscription: return "Subscription";
         case resource_type::operation_outcome: return "OperationOutcome";
         case resource_type::bundle: return "Bundle";
         case resource_type::capability_statement: return "CapabilityStatement";

--- a/include/pacs/bridge/fhir/subscription_manager.h
+++ b/include/pacs/bridge/fhir/subscription_manager.h
@@ -1,0 +1,545 @@
+#ifndef PACS_BRIDGE_FHIR_SUBSCRIPTION_MANAGER_H
+#define PACS_BRIDGE_FHIR_SUBSCRIPTION_MANAGER_H
+
+/**
+ * @file subscription_manager.h
+ * @brief FHIR Subscription manager implementation
+ *
+ * Manages FHIR Subscription resources and handles event-based notifications
+ * when studies become available or reports are completed.
+ *
+ * @see https://hl7.org/fhir/R4/subscription.html
+ * @see https://github.com/kcenon/pacs_bridge/issues/36
+ */
+
+#include "fhir_resource.h"
+#include "fhir_types.h"
+#include "resource_handler.h"
+#include "subscription_resource.h"
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pacs::bridge::fhir {
+
+// =============================================================================
+// Subscription Storage Interface
+// =============================================================================
+
+/**
+ * @brief Subscription storage interface
+ *
+ * Abstracts the subscription storage to allow different backend implementations
+ * (in-memory cache, database, etc.).
+ */
+class subscription_storage {
+public:
+    virtual ~subscription_storage() = default;
+
+    /**
+     * @brief Store a subscription
+     * @param id Subscription ID
+     * @param subscription Subscription data
+     * @return true on success
+     */
+    [[nodiscard]] virtual bool store(
+        const std::string& id,
+        const subscription_resource& subscription) = 0;
+
+    /**
+     * @brief Get subscription by ID
+     * @param id Subscription ID
+     * @return Subscription or nullptr if not found
+     */
+    [[nodiscard]] virtual std::unique_ptr<subscription_resource> get(
+        const std::string& id) const = 0;
+
+    /**
+     * @brief Update a subscription
+     * @param id Subscription ID
+     * @param subscription Updated subscription data
+     * @return true on success
+     */
+    [[nodiscard]] virtual bool update(
+        const std::string& id,
+        const subscription_resource& subscription) = 0;
+
+    /**
+     * @brief Remove a subscription
+     * @param id Subscription ID
+     * @return true if removed
+     */
+    [[nodiscard]] virtual bool remove(const std::string& id) = 0;
+
+    /**
+     * @brief Get all active subscriptions
+     * @return List of active subscriptions
+     */
+    [[nodiscard]] virtual std::vector<std::unique_ptr<subscription_resource>>
+    get_active() const = 0;
+
+    /**
+     * @brief Get subscriptions by criteria resource type
+     * @param resource_type Resource type to filter by
+     * @return List of matching subscriptions
+     */
+    [[nodiscard]] virtual std::vector<std::unique_ptr<subscription_resource>>
+    get_by_resource_type(const std::string& resource_type) const = 0;
+
+    /**
+     * @brief Get all subscription IDs
+     * @return List of subscription IDs
+     */
+    [[nodiscard]] virtual std::vector<std::string> keys() const = 0;
+
+    /**
+     * @brief Clear all subscriptions
+     */
+    virtual void clear() = 0;
+};
+
+/**
+ * @brief In-memory subscription storage implementation
+ */
+class in_memory_subscription_storage : public subscription_storage {
+public:
+    in_memory_subscription_storage();
+    ~in_memory_subscription_storage() override;
+
+    // Non-copyable, non-movable (contains mutex)
+    in_memory_subscription_storage(const in_memory_subscription_storage&) = delete;
+    in_memory_subscription_storage& operator=(const in_memory_subscription_storage&) = delete;
+    in_memory_subscription_storage(in_memory_subscription_storage&&) = delete;
+    in_memory_subscription_storage& operator=(in_memory_subscription_storage&&) = delete;
+
+    [[nodiscard]] bool store(
+        const std::string& id,
+        const subscription_resource& subscription) override;
+    [[nodiscard]] std::unique_ptr<subscription_resource> get(
+        const std::string& id) const override;
+    [[nodiscard]] bool update(
+        const std::string& id,
+        const subscription_resource& subscription) override;
+    [[nodiscard]] bool remove(const std::string& id) override;
+    [[nodiscard]] std::vector<std::unique_ptr<subscription_resource>>
+    get_active() const override;
+    [[nodiscard]] std::vector<std::unique_ptr<subscription_resource>>
+    get_by_resource_type(const std::string& resource_type) const override;
+    [[nodiscard]] std::vector<std::string> keys() const override;
+    void clear() override;
+
+private:
+    class impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+// =============================================================================
+// Notification Delivery Interface
+// =============================================================================
+
+/**
+ * @brief HTTP client interface for REST-hook delivery
+ */
+class http_client {
+public:
+    virtual ~http_client() = default;
+
+    /**
+     * @brief HTTP response from delivery attempt
+     */
+    struct response {
+        int status_code = 0;
+        std::string body;
+        std::map<std::string, std::string> headers;
+        std::optional<std::string> error;
+    };
+
+    /**
+     * @brief Send HTTP POST request
+     * @param url Target URL
+     * @param body Request body
+     * @param headers Request headers
+     * @param timeout Request timeout
+     * @return Response or error
+     */
+    [[nodiscard]] virtual response post(
+        const std::string& url,
+        const std::string& body,
+        const std::map<std::string, std::string>& headers,
+        std::chrono::milliseconds timeout) = 0;
+};
+
+/**
+ * @brief Create default HTTP client implementation
+ */
+[[nodiscard]] std::unique_ptr<http_client> create_http_client();
+
+/**
+ * @brief Notification delivery configuration
+ */
+struct delivery_config {
+    /** Maximum number of retry attempts */
+    uint32_t max_retries = 3;
+
+    /** Initial retry delay (doubles with each attempt) */
+    std::chrono::seconds initial_retry_delay{5};
+
+    /** Maximum retry delay */
+    std::chrono::seconds max_retry_delay{300};
+
+    /** Request timeout */
+    std::chrono::milliseconds request_timeout{30000};
+
+    /** Enable delivery (can be disabled for testing) */
+    bool enabled = true;
+};
+
+// =============================================================================
+// Subscription Manager
+// =============================================================================
+
+/**
+ * @brief Event callback for subscription notifications
+ */
+using subscription_event_callback = std::function<void(
+    const std::string& subscription_id,
+    const fhir_resource& resource,
+    delivery_status status,
+    const std::optional<std::string>& error)>;
+
+/**
+ * @brief Subscription manager statistics
+ */
+struct subscription_manager_stats {
+    size_t active_subscriptions = 0;
+    size_t total_notifications_sent = 0;
+    size_t successful_deliveries = 0;
+    size_t failed_deliveries = 0;
+    size_t pending_notifications = 0;
+};
+
+/**
+ * @brief FHIR Subscription Manager
+ *
+ * Manages FHIR Subscription resources and handles event-based notifications.
+ * Supports REST-hook channel type for delivering notifications.
+ *
+ * @example Basic Usage
+ * ```cpp
+ * auto storage = std::make_shared<in_memory_subscription_storage>();
+ * subscription_manager manager(storage);
+ *
+ * // Start the manager
+ * manager.start();
+ *
+ * // Create a subscription
+ * subscription_resource sub;
+ * sub.set_status(subscription_status::active);
+ * sub.set_criteria("ImagingStudy?status=available");
+ * subscription_channel channel;
+ * channel.type = subscription_channel_type::rest_hook;
+ * channel.endpoint = "https://emr.hospital.local/fhir-notify";
+ * channel.payload = "application/fhir+json";
+ * sub.set_channel(channel);
+ *
+ * auto result = manager.create_subscription(sub);
+ * if (is_success(result)) {
+ *     auto& created = get_resource(result);
+ *     std::cout << "Created: " << created->id() << std::endl;
+ * }
+ *
+ * // Notify subscribers when a study becomes available
+ * imaging_study_resource study;
+ * // ... populate study ...
+ * manager.notify(study);
+ *
+ * // Stop the manager
+ * manager.stop();
+ * ```
+ *
+ * Thread-safety: All operations are thread-safe.
+ */
+class subscription_manager {
+public:
+    /**
+     * @brief Constructor
+     * @param storage Subscription storage backend
+     * @param delivery_cfg Delivery configuration
+     */
+    explicit subscription_manager(
+        std::shared_ptr<subscription_storage> storage,
+        const delivery_config& delivery_cfg = delivery_config{});
+
+    /**
+     * @brief Constructor with custom HTTP client
+     * @param storage Subscription storage backend
+     * @param client HTTP client for REST-hook delivery
+     * @param delivery_cfg Delivery configuration
+     */
+    subscription_manager(
+        std::shared_ptr<subscription_storage> storage,
+        std::unique_ptr<http_client> client,
+        const delivery_config& delivery_cfg = delivery_config{});
+
+    /**
+     * @brief Destructor
+     */
+    ~subscription_manager();
+
+    // Non-copyable, non-movable
+    subscription_manager(const subscription_manager&) = delete;
+    subscription_manager& operator=(const subscription_manager&) = delete;
+    subscription_manager(subscription_manager&&) = delete;
+    subscription_manager& operator=(subscription_manager&&) = delete;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * @brief Start the subscription manager
+     *
+     * Starts background threads for notification delivery and retry processing.
+     *
+     * @return true if started successfully
+     */
+    [[nodiscard]] bool start();
+
+    /**
+     * @brief Stop the subscription manager
+     *
+     * Stops background threads and waits for pending deliveries to complete.
+     *
+     * @param wait_for_pending Wait for pending notifications to be delivered
+     */
+    void stop(bool wait_for_pending = true);
+
+    /**
+     * @brief Check if manager is running
+     */
+    [[nodiscard]] bool is_running() const noexcept;
+
+    // =========================================================================
+    // CRUD Operations
+    // =========================================================================
+
+    /**
+     * @brief Create a new subscription
+     *
+     * @param subscription Subscription to create
+     * @return Created subscription with assigned ID, or OperationOutcome
+     */
+    [[nodiscard]] resource_result<std::unique_ptr<subscription_resource>>
+    create_subscription(const subscription_resource& subscription);
+
+    /**
+     * @brief Get a subscription by ID
+     *
+     * @param id Subscription ID
+     * @return Subscription or OperationOutcome
+     */
+    [[nodiscard]] resource_result<std::unique_ptr<subscription_resource>>
+    get_subscription(const std::string& id);
+
+    /**
+     * @brief Update a subscription
+     *
+     * @param id Subscription ID
+     * @param subscription Updated subscription
+     * @return Updated subscription or OperationOutcome
+     */
+    [[nodiscard]] resource_result<std::unique_ptr<subscription_resource>>
+    update_subscription(const std::string& id,
+                       const subscription_resource& subscription);
+
+    /**
+     * @brief Delete a subscription
+     *
+     * @param id Subscription ID
+     * @return Empty outcome on success, or error outcome
+     */
+    [[nodiscard]] resource_result<std::monostate>
+    delete_subscription(const std::string& id);
+
+    /**
+     * @brief List all subscriptions
+     *
+     * @return List of all subscriptions
+     */
+    [[nodiscard]] std::vector<std::unique_ptr<subscription_resource>>
+    list_subscriptions() const;
+
+    // =========================================================================
+    // Notification
+    // =========================================================================
+
+    /**
+     * @brief Notify subscribers of a resource event
+     *
+     * Finds all active subscriptions whose criteria match the resource
+     * and delivers notifications via REST-hook.
+     *
+     * @param resource Resource that triggered the event
+     */
+    void notify(const fhir_resource& resource);
+
+    /**
+     * @brief Set event callback
+     *
+     * @param callback Callback to invoke on notification events
+     */
+    void set_event_callback(subscription_event_callback callback);
+
+    /**
+     * @brief Clear event callback
+     */
+    void clear_event_callback();
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    /**
+     * @brief Get manager statistics
+     */
+    [[nodiscard]] subscription_manager_stats get_statistics() const;
+
+    /**
+     * @brief Get delivery configuration
+     */
+    [[nodiscard]] const delivery_config& config() const noexcept;
+
+private:
+    class impl;
+    std::unique_ptr<impl> impl_;
+};
+
+// =============================================================================
+// Subscription Resource Handler
+// =============================================================================
+
+/**
+ * @brief Handler for FHIR Subscription resource operations
+ *
+ * Implements CRUD operations for Subscription resources.
+ *
+ * Supported operations:
+ * - create: POST /Subscription
+ * - read: GET /Subscription/{id}
+ * - update: PUT /Subscription/{id}
+ * - delete: DELETE /Subscription/{id}
+ * - search: GET /Subscription?status=xxx
+ *
+ * @example Basic Usage
+ * ```cpp
+ * auto manager = std::make_shared<subscription_manager>(storage);
+ * auto handler = std::make_shared<subscription_handler>(manager);
+ *
+ * // Register with FHIR server
+ * server.register_handler(handler);
+ * ```
+ *
+ * Thread-safety: All operations are thread-safe.
+ */
+class subscription_handler : public resource_handler {
+public:
+    /**
+     * @brief Constructor
+     * @param manager Subscription manager
+     */
+    explicit subscription_handler(
+        std::shared_ptr<subscription_manager> manager);
+
+    /**
+     * @brief Destructor
+     */
+    ~subscription_handler() override;
+
+    // Non-copyable, movable
+    subscription_handler(const subscription_handler&) = delete;
+    subscription_handler& operator=(const subscription_handler&) = delete;
+    subscription_handler(subscription_handler&&) noexcept;
+    subscription_handler& operator=(subscription_handler&&) noexcept;
+
+    // =========================================================================
+    // resource_handler Interface
+    // =========================================================================
+
+    /**
+     * @brief Get handled resource type
+     */
+    [[nodiscard]] resource_type handled_type() const noexcept override;
+
+    /**
+     * @brief Get resource type name
+     */
+    [[nodiscard]] std::string_view type_name() const noexcept override;
+
+    /**
+     * @brief Read subscription by ID
+     */
+    [[nodiscard]] resource_result<std::unique_ptr<fhir_resource>> read(
+        const std::string& id) override;
+
+    /**
+     * @brief Create a new subscription
+     */
+    [[nodiscard]] resource_result<std::unique_ptr<fhir_resource>> create(
+        std::unique_ptr<fhir_resource> resource) override;
+
+    /**
+     * @brief Update a subscription
+     */
+    [[nodiscard]] resource_result<std::unique_ptr<fhir_resource>> update(
+        const std::string& id,
+        std::unique_ptr<fhir_resource> resource) override;
+
+    /**
+     * @brief Delete a subscription
+     */
+    [[nodiscard]] resource_result<std::monostate> delete_resource(
+        const std::string& id) override;
+
+    /**
+     * @brief Search for subscriptions
+     *
+     * Supported search parameters:
+     * - _id: Resource ID
+     * - status: Subscription status
+     * - criteria: Subscription criteria
+     */
+    [[nodiscard]] resource_result<search_result> search(
+        const std::map<std::string, std::string>& params,
+        const pagination_params& pagination) override;
+
+    /**
+     * @brief Get supported search parameters
+     */
+    [[nodiscard]] std::map<std::string, std::string>
+    supported_search_params() const override;
+
+    /**
+     * @brief Check if interaction is supported
+     */
+    [[nodiscard]] bool supports_interaction(
+        interaction_type type) const noexcept override;
+
+    /**
+     * @brief Get supported interactions
+     */
+    [[nodiscard]] std::vector<interaction_type>
+    supported_interactions() const override;
+
+private:
+    class impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+}  // namespace pacs::bridge::fhir
+
+#endif  // PACS_BRIDGE_FHIR_SUBSCRIPTION_MANAGER_H

--- a/include/pacs/bridge/fhir/subscription_resource.h
+++ b/include/pacs/bridge/fhir/subscription_resource.h
@@ -1,0 +1,405 @@
+#ifndef PACS_BRIDGE_FHIR_SUBSCRIPTION_RESOURCE_H
+#define PACS_BRIDGE_FHIR_SUBSCRIPTION_RESOURCE_H
+
+/**
+ * @file subscription_resource.h
+ * @brief FHIR Subscription resource implementation
+ *
+ * Implements the FHIR R4 Subscription resource for event-based notifications
+ * when studies become available or reports are completed.
+ *
+ * @see https://hl7.org/fhir/R4/subscription.html
+ * @see https://github.com/kcenon/pacs_bridge/issues/36
+ */
+
+#include "fhir_resource.h"
+#include "fhir_types.h"
+#include "resource_handler.h"
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace pacs::bridge::fhir {
+
+// =============================================================================
+// FHIR Subscription Status Codes
+// =============================================================================
+
+/**
+ * @brief FHIR Subscription status codes
+ *
+ * @see https://hl7.org/fhir/R4/valueset-subscription-status.html
+ */
+enum class subscription_status {
+    requested,
+    active,
+    error,
+    off
+};
+
+/**
+ * @brief Convert subscription_status to FHIR code string
+ */
+[[nodiscard]] constexpr std::string_view to_string(
+    subscription_status status) noexcept {
+    switch (status) {
+        case subscription_status::requested: return "requested";
+        case subscription_status::active: return "active";
+        case subscription_status::error: return "error";
+        case subscription_status::off: return "off";
+    }
+    return "off";
+}
+
+/**
+ * @brief Parse subscription_status from string
+ */
+[[nodiscard]] std::optional<subscription_status> parse_subscription_status(
+    std::string_view status_str) noexcept;
+
+// =============================================================================
+// FHIR Subscription Channel Types
+// =============================================================================
+
+/**
+ * @brief FHIR Subscription channel types
+ *
+ * @see https://hl7.org/fhir/R4/valueset-subscription-channel-type.html
+ */
+enum class subscription_channel_type {
+    rest_hook,
+    websocket,
+    email,
+    message
+};
+
+/**
+ * @brief Convert subscription_channel_type to FHIR code string
+ */
+[[nodiscard]] constexpr std::string_view to_string(
+    subscription_channel_type type) noexcept {
+    switch (type) {
+        case subscription_channel_type::rest_hook: return "rest-hook";
+        case subscription_channel_type::websocket: return "websocket";
+        case subscription_channel_type::email: return "email";
+        case subscription_channel_type::message: return "message";
+    }
+    return "rest-hook";
+}
+
+/**
+ * @brief Parse subscription_channel_type from string
+ */
+[[nodiscard]] std::optional<subscription_channel_type> parse_channel_type(
+    std::string_view type_str) noexcept;
+
+// =============================================================================
+// FHIR Subscription Data Types
+// =============================================================================
+
+/**
+ * @brief FHIR Subscription.channel element
+ *
+ * Details where notifications should be sent.
+ * @see https://hl7.org/fhir/R4/subscription-definitions.html#Subscription.channel
+ */
+struct subscription_channel {
+    /** The type of channel to send notifications on */
+    subscription_channel_type type = subscription_channel_type::rest_hook;
+
+    /** The url that describes the actual end-point to send notifications */
+    std::string endpoint;
+
+    /** MIME type to send (e.g., "application/fhir+json") */
+    std::optional<std::string> payload;
+
+    /** Additional headers for rest-hook channel */
+    std::vector<std::string> header;
+};
+
+/**
+ * @brief Subscription delivery status for tracking
+ */
+enum class delivery_status {
+    pending,
+    in_progress,
+    completed,
+    failed,
+    abandoned
+};
+
+/**
+ * @brief Convert delivery_status to string
+ */
+[[nodiscard]] constexpr std::string_view to_string(
+    delivery_status status) noexcept {
+    switch (status) {
+        case delivery_status::pending: return "pending";
+        case delivery_status::in_progress: return "in-progress";
+        case delivery_status::completed: return "completed";
+        case delivery_status::failed: return "failed";
+        case delivery_status::abandoned: return "abandoned";
+    }
+    return "pending";
+}
+
+/**
+ * @brief Parse delivery_status from string
+ */
+[[nodiscard]] std::optional<delivery_status> parse_delivery_status(
+    std::string_view status_str) noexcept;
+
+/**
+ * @brief Delivery attempt record
+ */
+struct delivery_attempt {
+    std::chrono::system_clock::time_point timestamp;
+    delivery_status status = delivery_status::pending;
+    std::optional<int> http_status_code;
+    std::optional<std::string> error_message;
+    uint32_t attempt_number = 0;
+};
+
+/**
+ * @brief Notification delivery record
+ */
+struct notification_record {
+    std::string id;
+    std::string subscription_id;
+    std::string resource_type;
+    std::string resource_id;
+    std::chrono::system_clock::time_point created_at;
+    delivery_status status = delivery_status::pending;
+    std::vector<delivery_attempt> attempts;
+    uint32_t retry_count = 0;
+    std::optional<std::chrono::system_clock::time_point> next_retry_at;
+};
+
+// =============================================================================
+// FHIR Subscription Resource
+// =============================================================================
+
+/**
+ * @brief FHIR R4 Subscription resource
+ *
+ * Represents subscription information per FHIR R4 specification.
+ * Used for event-based notifications when studies become available
+ * or reports are completed.
+ *
+ * @example Creating a Subscription Resource
+ * ```cpp
+ * subscription_resource subscription;
+ * subscription.set_id("subscription-123");
+ * subscription.set_status(subscription_status::active);
+ *
+ * // Set criteria for ImagingStudy availability notifications
+ * subscription.set_criteria("ImagingStudy?status=available");
+ *
+ * // Set reason
+ * subscription.set_reason("Monitor for completed studies");
+ *
+ * // Configure channel
+ * subscription_channel channel;
+ * channel.type = subscription_channel_type::rest_hook;
+ * channel.endpoint = "https://emr.hospital.local/fhir-notify";
+ * channel.payload = "application/fhir+json";
+ * channel.header.push_back("Authorization: Bearer xxx");
+ * subscription.set_channel(channel);
+ *
+ * // Serialize to JSON
+ * std::string json = subscription.to_json();
+ * ```
+ *
+ * @see https://hl7.org/fhir/R4/subscription.html
+ */
+class subscription_resource : public fhir_resource {
+public:
+    /**
+     * @brief Default constructor
+     */
+    subscription_resource();
+
+    /**
+     * @brief Destructor
+     */
+    ~subscription_resource() override;
+
+    // Non-copyable, movable
+    subscription_resource(const subscription_resource&) = delete;
+    subscription_resource& operator=(const subscription_resource&) = delete;
+    subscription_resource(subscription_resource&&) noexcept;
+    subscription_resource& operator=(subscription_resource&&) noexcept;
+
+    // =========================================================================
+    // fhir_resource Interface
+    // =========================================================================
+
+    /**
+     * @brief Get resource type
+     */
+    [[nodiscard]] resource_type type() const noexcept override;
+
+    /**
+     * @brief Get resource type name
+     */
+    [[nodiscard]] std::string type_name() const override;
+
+    /**
+     * @brief Serialize to JSON
+     */
+    [[nodiscard]] std::string to_json() const override;
+
+    /**
+     * @brief Validate the resource
+     */
+    [[nodiscard]] bool validate() const override;
+
+    // =========================================================================
+    // Status
+    // =========================================================================
+
+    /**
+     * @brief Set status (required)
+     */
+    void set_status(subscription_status status);
+
+    /**
+     * @brief Get status
+     */
+    [[nodiscard]] subscription_status status() const noexcept;
+
+    // =========================================================================
+    // Contact Information
+    // =========================================================================
+
+    /**
+     * @brief Add a contact point
+     */
+    void add_contact(const std::string& contact);
+
+    /**
+     * @brief Get all contact points
+     */
+    [[nodiscard]] const std::vector<std::string>& contacts() const noexcept;
+
+    /**
+     * @brief Clear all contact points
+     */
+    void clear_contacts();
+
+    // =========================================================================
+    // Subscription Details
+    // =========================================================================
+
+    /**
+     * @brief Set end time (when subscription should expire)
+     */
+    void set_end(std::string datetime);
+
+    /**
+     * @brief Get end time
+     */
+    [[nodiscard]] const std::optional<std::string>& end() const noexcept;
+
+    /**
+     * @brief Set reason for the subscription
+     */
+    void set_reason(std::string reason);
+
+    /**
+     * @brief Get reason
+     */
+    [[nodiscard]] const std::optional<std::string>& reason() const noexcept;
+
+    /**
+     * @brief Set criteria (search URL for triggering events)
+     */
+    void set_criteria(std::string criteria);
+
+    /**
+     * @brief Get criteria
+     */
+    [[nodiscard]] const std::string& criteria() const noexcept;
+
+    /**
+     * @brief Set error message (populated when status is "error")
+     */
+    void set_error(std::string error);
+
+    /**
+     * @brief Get error message
+     */
+    [[nodiscard]] const std::optional<std::string>& error() const noexcept;
+
+    // =========================================================================
+    // Channel
+    // =========================================================================
+
+    /**
+     * @brief Set channel (required)
+     */
+    void set_channel(const subscription_channel& channel);
+
+    /**
+     * @brief Get channel
+     */
+    [[nodiscard]] const subscription_channel& channel() const noexcept;
+
+    // =========================================================================
+    // Factory Methods
+    // =========================================================================
+
+    /**
+     * @brief Create Subscription resource from JSON
+     * @param json JSON string
+     * @return Subscription resource or nullptr on parse error
+     */
+    [[nodiscard]] static std::unique_ptr<subscription_resource> from_json(
+        const std::string& json);
+
+private:
+    class impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+// =============================================================================
+// Criteria Matching
+// =============================================================================
+
+/**
+ * @brief Parsed criteria components
+ */
+struct parsed_criteria {
+    std::string resource_type;
+    std::map<std::string, std::string> params;
+};
+
+/**
+ * @brief Parse subscription criteria string
+ *
+ * Parses criteria like "ImagingStudy?status=available" into
+ * resource type and search parameters.
+ *
+ * @param criteria Criteria string
+ * @return Parsed criteria or nullopt if invalid
+ */
+[[nodiscard]] std::optional<parsed_criteria> parse_subscription_criteria(
+    std::string_view criteria) noexcept;
+
+/**
+ * @brief Check if a resource matches subscription criteria
+ *
+ * @param resource Resource to check
+ * @param criteria Parsed criteria
+ * @return true if resource matches criteria
+ */
+[[nodiscard]] bool matches_criteria(
+    const fhir_resource& resource,
+    const parsed_criteria& criteria);
+
+}  // namespace pacs::bridge::fhir
+
+#endif  // PACS_BRIDGE_FHIR_SUBSCRIPTION_RESOURCE_H

--- a/src/fhir/CMakeLists.txt
+++ b/src/fhir/CMakeLists.txt
@@ -13,6 +13,8 @@ set(FHIR_SOURCES
     patient_resource.cpp
     service_request_resource.cpp
     imaging_study_resource.cpp
+    subscription_resource.cpp
+    subscription_manager.cpp
 )
 
 set(FHIR_HEADERS
@@ -24,6 +26,8 @@ set(FHIR_HEADERS
     ${CMAKE_SOURCE_DIR}/include/pacs/bridge/fhir/patient_resource.h
     ${CMAKE_SOURCE_DIR}/include/pacs/bridge/fhir/service_request_resource.h
     ${CMAKE_SOURCE_DIR}/include/pacs/bridge/fhir/imaging_study_resource.h
+    ${CMAKE_SOURCE_DIR}/include/pacs/bridge/fhir/subscription_resource.h
+    ${CMAKE_SOURCE_DIR}/include/pacs/bridge/fhir/subscription_manager.h
 )
 
 # Export sources to parent scope for main library

--- a/src/fhir/fhir_types.cpp
+++ b/src/fhir/fhir_types.cpp
@@ -225,6 +225,9 @@ std::optional<resource_type> parse_resource_type(
     if (iequals(trimmed, "Endpoint")) {
         return resource_type::endpoint;
     }
+    if (iequals(trimmed, "Subscription")) {
+        return resource_type::subscription;
+    }
     if (iequals(trimmed, "OperationOutcome")) {
         return resource_type::operation_outcome;
     }

--- a/src/fhir/subscription_manager.cpp
+++ b/src/fhir/subscription_manager.cpp
@@ -1,0 +1,936 @@
+/**
+ * @file subscription_manager.cpp
+ * @brief FHIR Subscription manager implementation
+ *
+ * Implements the Subscription manager and handler for FHIR R4.
+ *
+ * @see include/pacs/bridge/fhir/subscription_manager.h
+ * @see https://github.com/kcenon/pacs_bridge/issues/36
+ */
+
+#include "pacs/bridge/fhir/subscription_manager.h"
+
+#include "pacs/bridge/integration/network_adapter.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <iomanip>
+#include <mutex>
+#include <queue>
+#include <random>
+#include <shared_mutex>
+#include <sstream>
+#include <thread>
+#include <unordered_map>
+
+namespace pacs::bridge::fhir {
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+namespace {
+
+std::string generate_uuid() {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<uint32_t> dis;
+
+    std::ostringstream ss;
+    ss << std::hex << std::setfill('0');
+    ss << std::setw(8) << dis(gen) << "-";
+    ss << std::setw(4) << (dis(gen) & 0xFFFF) << "-";
+    ss << std::setw(4) << ((dis(gen) & 0x0FFF) | 0x4000) << "-";
+    ss << std::setw(4) << ((dis(gen) & 0x3FFF) | 0x8000) << "-";
+    ss << std::setw(8) << dis(gen) << std::setw(4) << (dis(gen) & 0xFFFF);
+    return ss.str();
+}
+
+std::string json_escape(std::string_view input) {
+    std::string result;
+    result.reserve(input.size() + 10);
+
+    for (char c : input) {
+        switch (c) {
+            case '"':
+                result += "\\\"";
+                break;
+            case '\\':
+                result += "\\\\";
+                break;
+            case '\b':
+                result += "\\b";
+                break;
+            case '\f':
+                result += "\\f";
+                break;
+            case '\n':
+                result += "\\n";
+                break;
+            case '\r':
+                result += "\\r";
+                break;
+            case '\t':
+                result += "\\t";
+                break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    snprintf(buf, sizeof(buf), "\\u%04x",
+                             static_cast<unsigned int>(c));
+                    result += buf;
+                } else {
+                    result += c;
+                }
+                break;
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
+// =============================================================================
+// In-Memory Subscription Storage Implementation
+// =============================================================================
+
+class in_memory_subscription_storage::impl {
+public:
+    mutable std::shared_mutex mutex;
+    std::unordered_map<std::string, std::string> subscriptions;  // id -> JSON
+};
+
+in_memory_subscription_storage::in_memory_subscription_storage()
+    : pimpl_(std::make_unique<impl>()) {}
+
+in_memory_subscription_storage::~in_memory_subscription_storage() = default;
+
+bool in_memory_subscription_storage::store(
+    const std::string& id,
+    const subscription_resource& subscription) {
+    std::unique_lock lock(pimpl_->mutex);
+    pimpl_->subscriptions[id] = subscription.to_json();
+    return true;
+}
+
+std::unique_ptr<subscription_resource> in_memory_subscription_storage::get(
+    const std::string& id) const {
+    std::shared_lock lock(pimpl_->mutex);
+    auto it = pimpl_->subscriptions.find(id);
+    if (it == pimpl_->subscriptions.end()) {
+        return nullptr;
+    }
+    return subscription_resource::from_json(it->second);
+}
+
+bool in_memory_subscription_storage::update(
+    const std::string& id,
+    const subscription_resource& subscription) {
+    std::unique_lock lock(pimpl_->mutex);
+    auto it = pimpl_->subscriptions.find(id);
+    if (it == pimpl_->subscriptions.end()) {
+        return false;
+    }
+    it->second = subscription.to_json();
+    return true;
+}
+
+bool in_memory_subscription_storage::remove(const std::string& id) {
+    std::unique_lock lock(pimpl_->mutex);
+    return pimpl_->subscriptions.erase(id) > 0;
+}
+
+std::vector<std::unique_ptr<subscription_resource>>
+in_memory_subscription_storage::get_active() const {
+    std::vector<std::unique_ptr<subscription_resource>> result;
+    std::shared_lock lock(pimpl_->mutex);
+
+    for (const auto& [id, json] : pimpl_->subscriptions) {
+        auto sub = subscription_resource::from_json(json);
+        if (sub && sub->status() == subscription_status::active) {
+            result.push_back(std::move(sub));
+        }
+    }
+
+    return result;
+}
+
+std::vector<std::unique_ptr<subscription_resource>>
+in_memory_subscription_storage::get_by_resource_type(
+    const std::string& resource_type) const {
+    std::vector<std::unique_ptr<subscription_resource>> result;
+    std::shared_lock lock(pimpl_->mutex);
+
+    for (const auto& [id, json] : pimpl_->subscriptions) {
+        auto sub = subscription_resource::from_json(json);
+        if (sub && sub->status() == subscription_status::active) {
+            auto criteria = parse_subscription_criteria(sub->criteria());
+            if (criteria && criteria->resource_type == resource_type) {
+                result.push_back(std::move(sub));
+            }
+        }
+    }
+
+    return result;
+}
+
+std::vector<std::string> in_memory_subscription_storage::keys() const {
+    std::vector<std::string> result;
+    std::shared_lock lock(pimpl_->mutex);
+    result.reserve(pimpl_->subscriptions.size());
+
+    for (const auto& [id, json] : pimpl_->subscriptions) {
+        result.push_back(id);
+    }
+
+    return result;
+}
+
+void in_memory_subscription_storage::clear() {
+    std::unique_lock lock(pimpl_->mutex);
+    pimpl_->subscriptions.clear();
+}
+
+// =============================================================================
+// HTTP Client Implementation
+// =============================================================================
+
+/**
+ * @brief Stub HTTP client that always returns success
+ *
+ * This is a placeholder implementation. For production use, inject
+ * a real HTTP client implementation via the subscription_manager
+ * constructor that takes an http_client parameter.
+ *
+ * To implement a real HTTP client, you can:
+ * 1. Use libcurl
+ * 2. Use Boost.Beast
+ * 3. Implement using raw sockets with the network_adapter when available
+ */
+class stub_http_client : public http_client {
+public:
+    response post(
+        const std::string& url,
+        const std::string& body,
+        const std::map<std::string, std::string>& headers,
+        std::chrono::milliseconds timeout) override {
+        (void)url;
+        (void)body;
+        (void)headers;
+        (void)timeout;
+
+        response resp;
+        // Return success for now - actual delivery requires
+        // a real HTTP client implementation
+        resp.status_code = 200;
+        resp.body = "{}";
+        return resp;
+    }
+};
+
+std::unique_ptr<http_client> create_http_client() {
+    return std::make_unique<stub_http_client>();
+}
+
+// =============================================================================
+// Subscription Manager Implementation
+// =============================================================================
+
+struct pending_notification {
+    std::string subscription_id;
+    std::string resource_json;
+    std::string resource_type;
+    std::string resource_id;
+    std::chrono::system_clock::time_point created_at;
+    uint32_t retry_count = 0;
+    std::chrono::system_clock::time_point next_retry_at;
+};
+
+class subscription_manager::impl {
+public:
+    impl(std::shared_ptr<subscription_storage> storage,
+         std::unique_ptr<http_client> client,
+         const delivery_config& cfg)
+        : storage_(std::move(storage)),
+          client_(std::move(client)),
+          config_(cfg),
+          running_(false) {}
+
+    ~impl() {
+        stop(false);
+    }
+
+    bool start() {
+        if (running_.exchange(true)) {
+            return false;  // Already running
+        }
+
+        delivery_thread_ = std::thread([this] { delivery_loop(); });
+        retry_thread_ = std::thread([this] { retry_loop(); });
+
+        return true;
+    }
+
+    void stop(bool wait_for_pending) {
+        if (!running_.exchange(false)) {
+            return;  // Not running
+        }
+
+        if (wait_for_pending) {
+            // Wait for pending notifications
+            std::unique_lock lock(queue_mutex_);
+            queue_cv_.wait_for(lock, std::chrono::seconds(10), [this] {
+                return pending_queue_.empty();
+            });
+        }
+
+        queue_cv_.notify_all();
+        retry_cv_.notify_all();
+
+        if (delivery_thread_.joinable()) {
+            delivery_thread_.join();
+        }
+        if (retry_thread_.joinable()) {
+            retry_thread_.join();
+        }
+    }
+
+    bool is_running() const noexcept {
+        return running_.load();
+    }
+
+    resource_result<std::unique_ptr<subscription_resource>> create_subscription(
+        const subscription_resource& subscription) {
+        auto new_sub = std::make_unique<subscription_resource>();
+
+        // Copy properties
+        new_sub->set_status(subscription.status());
+        new_sub->set_criteria(subscription.criteria());
+        new_sub->set_channel(subscription.channel());
+
+        if (subscription.reason().has_value()) {
+            new_sub->set_reason(*subscription.reason());
+        }
+        if (subscription.end().has_value()) {
+            new_sub->set_end(*subscription.end());
+        }
+        for (const auto& contact : subscription.contacts()) {
+            new_sub->add_contact(contact);
+        }
+
+        // Generate ID
+        std::string id = generate_uuid();
+        new_sub->set_id(id);
+        new_sub->set_version_id("1");
+
+        // Validate
+        if (!new_sub->validate()) {
+            return operation_outcome::validation_error(
+                "Invalid subscription resource: missing required fields");
+        }
+
+        // Store
+        if (!storage_->store(id, *new_sub)) {
+            return operation_outcome::internal_error(
+                "Failed to store subscription");
+        }
+
+        // Update stats
+        if (new_sub->status() == subscription_status::active) {
+            ++stats_.active_subscriptions;
+        }
+
+        return new_sub;
+    }
+
+    resource_result<std::unique_ptr<subscription_resource>> get_subscription(
+        const std::string& id) {
+        auto sub = storage_->get(id);
+        if (!sub) {
+            return operation_outcome::not_found("Subscription", id);
+        }
+        return sub;
+    }
+
+    resource_result<std::unique_ptr<subscription_resource>> update_subscription(
+        const std::string& id,
+        const subscription_resource& subscription) {
+        auto existing = storage_->get(id);
+        if (!existing) {
+            return operation_outcome::not_found("Subscription", id);
+        }
+
+        auto updated = std::make_unique<subscription_resource>();
+
+        // Copy properties
+        updated->set_id(id);
+        updated->set_status(subscription.status());
+        updated->set_criteria(subscription.criteria());
+        updated->set_channel(subscription.channel());
+
+        if (subscription.reason().has_value()) {
+            updated->set_reason(*subscription.reason());
+        }
+        if (subscription.end().has_value()) {
+            updated->set_end(*subscription.end());
+        }
+        if (subscription.error().has_value()) {
+            updated->set_error(*subscription.error());
+        }
+        for (const auto& contact : subscription.contacts()) {
+            updated->add_contact(contact);
+        }
+
+        // Update version
+        std::string version_id = existing->version_id();
+        if (version_id.empty()) {
+            version_id = "1";
+        }
+        int version = std::stoi(version_id) + 1;
+        updated->set_version_id(std::to_string(version));
+
+        // Validate
+        if (!updated->validate()) {
+            return operation_outcome::validation_error(
+                "Invalid subscription resource: missing required fields");
+        }
+
+        // Update stats
+        if (existing->status() == subscription_status::active &&
+            updated->status() != subscription_status::active) {
+            --stats_.active_subscriptions;
+        } else if (existing->status() != subscription_status::active &&
+                   updated->status() == subscription_status::active) {
+            ++stats_.active_subscriptions;
+        }
+
+        // Store
+        if (!storage_->update(id, *updated)) {
+            return operation_outcome::internal_error(
+                "Failed to update subscription");
+        }
+
+        return updated;
+    }
+
+    resource_result<std::monostate> delete_subscription(const std::string& id) {
+        auto existing = storage_->get(id);
+        if (!existing) {
+            return operation_outcome::not_found("Subscription", id);
+        }
+
+        if (existing->status() == subscription_status::active) {
+            --stats_.active_subscriptions;
+        }
+
+        if (!storage_->remove(id)) {
+            return operation_outcome::internal_error(
+                "Failed to delete subscription");
+        }
+
+        return std::monostate{};
+    }
+
+    std::vector<std::unique_ptr<subscription_resource>> list_subscriptions() const {
+        std::vector<std::unique_ptr<subscription_resource>> result;
+        auto keys = storage_->keys();
+
+        for (const auto& key : keys) {
+            auto sub = storage_->get(key);
+            if (sub) {
+                result.push_back(std::move(sub));
+            }
+        }
+
+        return result;
+    }
+
+    void notify(const fhir_resource& resource) {
+        if (!config_.enabled || !running_.load()) {
+            return;
+        }
+
+        // Get matching subscriptions
+        auto subscriptions = storage_->get_by_resource_type(resource.type_name());
+
+        for (auto& sub : subscriptions) {
+            auto criteria = parse_subscription_criteria(sub->criteria());
+            if (!criteria || !matches_criteria(resource, *criteria)) {
+                continue;
+            }
+
+            // Create pending notification
+            pending_notification notification;
+            notification.subscription_id = sub->id();
+            notification.resource_json = resource.to_json();
+            notification.resource_type = resource.type_name();
+            notification.resource_id = resource.id();
+            notification.created_at = std::chrono::system_clock::now();
+            notification.retry_count = 0;
+            notification.next_retry_at = notification.created_at;
+
+            // Enqueue
+            {
+                std::lock_guard lock(queue_mutex_);
+                pending_queue_.push(std::move(notification));
+                ++stats_.pending_notifications;
+            }
+            queue_cv_.notify_one();
+        }
+    }
+
+    void set_event_callback(subscription_event_callback callback) {
+        std::lock_guard lock(callback_mutex_);
+        callback_ = std::move(callback);
+    }
+
+    void clear_event_callback() {
+        std::lock_guard lock(callback_mutex_);
+        callback_ = nullptr;
+    }
+
+    subscription_manager_stats get_statistics() const {
+        return stats_;
+    }
+
+    const delivery_config& config() const noexcept {
+        return config_;
+    }
+
+private:
+    void delivery_loop() {
+        while (running_.load()) {
+            pending_notification notification;
+
+            {
+                std::unique_lock lock(queue_mutex_);
+                queue_cv_.wait(lock, [this] {
+                    return !pending_queue_.empty() || !running_.load();
+                });
+
+                if (!running_.load()) {
+                    break;
+                }
+
+                if (pending_queue_.empty()) {
+                    continue;
+                }
+
+                notification = std::move(pending_queue_.front());
+                pending_queue_.pop();
+                --stats_.pending_notifications;
+            }
+
+            deliver_notification(notification);
+        }
+    }
+
+    void retry_loop() {
+        while (running_.load()) {
+            std::unique_lock lock(retry_mutex_);
+            retry_cv_.wait_for(lock, std::chrono::seconds(1), [this] {
+                return !running_.load();
+            });
+
+            if (!running_.load()) {
+                break;
+            }
+
+            // Process retry queue
+            auto now = std::chrono::system_clock::now();
+            std::vector<pending_notification> to_retry;
+
+            {
+                std::lock_guard retry_lock(retry_queue_mutex_);
+                auto it = retry_queue_.begin();
+                while (it != retry_queue_.end()) {
+                    if (it->next_retry_at <= now) {
+                        to_retry.push_back(std::move(*it));
+                        it = retry_queue_.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+            }
+
+            // Re-queue for delivery
+            for (auto& notification : to_retry) {
+                {
+                    std::lock_guard lock(queue_mutex_);
+                    pending_queue_.push(std::move(notification));
+                    ++stats_.pending_notifications;
+                }
+                queue_cv_.notify_one();
+            }
+        }
+    }
+
+    void deliver_notification(pending_notification& notification) {
+        auto sub = storage_->get(notification.subscription_id);
+        if (!sub || sub->status() != subscription_status::active) {
+            return;
+        }
+
+        const auto& channel = sub->channel();
+        if (channel.type != subscription_channel_type::rest_hook) {
+            return;
+        }
+
+        // Build headers
+        std::map<std::string, std::string> headers;
+        headers["Content-Type"] = channel.payload.value_or("application/fhir+json");
+
+        for (const auto& header : channel.header) {
+            auto colon_pos = header.find(':');
+            if (colon_pos != std::string::npos) {
+                std::string key = header.substr(0, colon_pos);
+                std::string value = header.substr(colon_pos + 1);
+                // Trim leading whitespace from value
+                while (!value.empty() && value[0] == ' ') {
+                    value = value.substr(1);
+                }
+                headers[key] = value;
+            }
+        }
+
+        // Deliver
+        ++stats_.total_notifications_sent;
+
+        auto response = client_->post(
+            channel.endpoint,
+            notification.resource_json,
+            headers,
+            config_.request_timeout);
+
+        bool success = (response.status_code >= 200 && response.status_code < 300);
+
+        if (success) {
+            ++stats_.successful_deliveries;
+
+            // Invoke callback
+            std::lock_guard lock(callback_mutex_);
+            if (callback_) {
+                callback_(
+                    notification.subscription_id,
+                    *subscription_resource::from_json(notification.resource_json),
+                    delivery_status::completed,
+                    std::nullopt);
+            }
+        } else {
+            // Handle failure
+            ++notification.retry_count;
+
+            std::string error_msg = response.error.value_or(
+                "HTTP " + std::to_string(response.status_code));
+
+            if (notification.retry_count < config_.max_retries) {
+                // Schedule retry
+                auto delay = std::min(
+                    config_.initial_retry_delay * (1 << notification.retry_count),
+                    config_.max_retry_delay);
+                notification.next_retry_at =
+                    std::chrono::system_clock::now() + delay;
+
+                {
+                    std::lock_guard lock(retry_queue_mutex_);
+                    retry_queue_.push_back(std::move(notification));
+                }
+            } else {
+                // Max retries reached
+                ++stats_.failed_deliveries;
+
+                // Invoke callback
+                std::lock_guard lock(callback_mutex_);
+                if (callback_) {
+                    callback_(
+                        notification.subscription_id,
+                        *subscription_resource::from_json(notification.resource_json),
+                        delivery_status::abandoned,
+                        error_msg);
+                }
+
+                // Optionally set subscription to error state
+                auto existing = storage_->get(notification.subscription_id);
+                if (existing) {
+                    existing->set_status(subscription_status::error);
+                    existing->set_error(error_msg);
+                    storage_->update(notification.subscription_id, *existing);
+                    --stats_.active_subscriptions;
+                }
+            }
+        }
+    }
+
+    std::shared_ptr<subscription_storage> storage_;
+    std::unique_ptr<http_client> client_;
+    delivery_config config_;
+
+    std::atomic<bool> running_;
+    std::thread delivery_thread_;
+    std::thread retry_thread_;
+
+    std::mutex queue_mutex_;
+    std::condition_variable queue_cv_;
+    std::queue<pending_notification> pending_queue_;
+
+    std::mutex retry_mutex_;
+    std::condition_variable retry_cv_;
+    std::mutex retry_queue_mutex_;
+    std::vector<pending_notification> retry_queue_;
+
+    std::mutex callback_mutex_;
+    subscription_event_callback callback_;
+
+    mutable subscription_manager_stats stats_;
+};
+
+// =============================================================================
+// Subscription Manager Public Interface
+// =============================================================================
+
+subscription_manager::subscription_manager(
+    std::shared_ptr<subscription_storage> storage,
+    const delivery_config& delivery_cfg)
+    : impl_(std::make_unique<impl>(
+          std::move(storage),
+          create_http_client(),
+          delivery_cfg)) {}
+
+subscription_manager::subscription_manager(
+    std::shared_ptr<subscription_storage> storage,
+    std::unique_ptr<http_client> client,
+    const delivery_config& delivery_cfg)
+    : impl_(std::make_unique<impl>(
+          std::move(storage),
+          std::move(client),
+          delivery_cfg)) {}
+
+subscription_manager::~subscription_manager() = default;
+
+bool subscription_manager::start() {
+    return impl_->start();
+}
+
+void subscription_manager::stop(bool wait_for_pending) {
+    impl_->stop(wait_for_pending);
+}
+
+bool subscription_manager::is_running() const noexcept {
+    return impl_->is_running();
+}
+
+resource_result<std::unique_ptr<subscription_resource>>
+subscription_manager::create_subscription(const subscription_resource& subscription) {
+    return impl_->create_subscription(subscription);
+}
+
+resource_result<std::unique_ptr<subscription_resource>>
+subscription_manager::get_subscription(const std::string& id) {
+    return impl_->get_subscription(id);
+}
+
+resource_result<std::unique_ptr<subscription_resource>>
+subscription_manager::update_subscription(
+    const std::string& id,
+    const subscription_resource& subscription) {
+    return impl_->update_subscription(id, subscription);
+}
+
+resource_result<std::monostate>
+subscription_manager::delete_subscription(const std::string& id) {
+    return impl_->delete_subscription(id);
+}
+
+std::vector<std::unique_ptr<subscription_resource>>
+subscription_manager::list_subscriptions() const {
+    return impl_->list_subscriptions();
+}
+
+void subscription_manager::notify(const fhir_resource& resource) {
+    impl_->notify(resource);
+}
+
+void subscription_manager::set_event_callback(subscription_event_callback callback) {
+    impl_->set_event_callback(std::move(callback));
+}
+
+void subscription_manager::clear_event_callback() {
+    impl_->clear_event_callback();
+}
+
+subscription_manager_stats subscription_manager::get_statistics() const {
+    return impl_->get_statistics();
+}
+
+const delivery_config& subscription_manager::config() const noexcept {
+    return impl_->config();
+}
+
+// =============================================================================
+// Subscription Handler Implementation
+// =============================================================================
+
+class subscription_handler::impl {
+public:
+    explicit impl(std::shared_ptr<subscription_manager> manager)
+        : manager_(std::move(manager)) {}
+
+    std::shared_ptr<subscription_manager> manager_;
+};
+
+subscription_handler::subscription_handler(
+    std::shared_ptr<subscription_manager> manager)
+    : pimpl_(std::make_unique<impl>(std::move(manager))) {}
+
+subscription_handler::~subscription_handler() = default;
+
+subscription_handler::subscription_handler(
+    subscription_handler&&) noexcept = default;
+
+subscription_handler& subscription_handler::operator=(
+    subscription_handler&&) noexcept = default;
+
+resource_type subscription_handler::handled_type() const noexcept {
+    return resource_type::subscription;
+}
+
+std::string_view subscription_handler::type_name() const noexcept {
+    return "Subscription";
+}
+
+resource_result<std::unique_ptr<fhir_resource>> subscription_handler::read(
+    const std::string& id) {
+    auto result = pimpl_->manager_->get_subscription(id);
+    if (is_success(result)) {
+        auto& sub = std::get<std::unique_ptr<subscription_resource>>(result);
+        return std::unique_ptr<fhir_resource>(sub.release());
+    }
+    return get_outcome(result);
+}
+
+resource_result<std::unique_ptr<fhir_resource>> subscription_handler::create(
+    std::unique_ptr<fhir_resource> resource) {
+    auto* subscription = dynamic_cast<subscription_resource*>(resource.get());
+    if (!subscription) {
+        return operation_outcome::validation_error(
+            "Invalid resource type: expected Subscription");
+    }
+
+    auto result = pimpl_->manager_->create_subscription(*subscription);
+    if (is_success(result)) {
+        auto& sub = std::get<std::unique_ptr<subscription_resource>>(result);
+        return std::unique_ptr<fhir_resource>(sub.release());
+    }
+    return get_outcome(result);
+}
+
+resource_result<std::unique_ptr<fhir_resource>> subscription_handler::update(
+    const std::string& id,
+    std::unique_ptr<fhir_resource> resource) {
+    auto* subscription = dynamic_cast<subscription_resource*>(resource.get());
+    if (!subscription) {
+        return operation_outcome::validation_error(
+            "Invalid resource type: expected Subscription");
+    }
+
+    auto result = pimpl_->manager_->update_subscription(id, *subscription);
+    if (is_success(result)) {
+        auto& sub = std::get<std::unique_ptr<subscription_resource>>(result);
+        return std::unique_ptr<fhir_resource>(sub.release());
+    }
+    return get_outcome(result);
+}
+
+resource_result<std::monostate> subscription_handler::delete_resource(
+    const std::string& id) {
+    return pimpl_->manager_->delete_subscription(id);
+}
+
+resource_result<search_result> subscription_handler::search(
+    const std::map<std::string, std::string>& params,
+    const pagination_params& pagination) {
+    search_result result;
+
+    auto all_subs = pimpl_->manager_->list_subscriptions();
+
+    // Filter based on search parameters
+    std::vector<std::unique_ptr<subscription_resource>> matching;
+
+    for (auto& sub : all_subs) {
+        bool matches = true;
+
+        for (const auto& [param_name, param_value] : params) {
+            if (param_name == "_id") {
+                if (sub->id() != param_value) {
+                    matches = false;
+                    break;
+                }
+            } else if (param_name == "status") {
+                if (to_string(sub->status()) != param_value) {
+                    matches = false;
+                    break;
+                }
+            } else if (param_name == "criteria") {
+                if (sub->criteria().find(param_value) == std::string::npos) {
+                    matches = false;
+                    break;
+                }
+            }
+        }
+
+        if (matches) {
+            matching.push_back(std::move(sub));
+        }
+    }
+
+    result.total = matching.size();
+
+    // Apply pagination
+    size_t start = pagination.offset;
+    size_t count = pagination.count;
+
+    if (start >= matching.size()) {
+        return result;
+    }
+
+    size_t end = std::min(start + count, matching.size());
+
+    for (size_t i = start; i < end; ++i) {
+        result.entries.push_back(std::move(matching[i]));
+        result.search_modes.push_back("match");
+    }
+
+    return result;
+}
+
+std::map<std::string, std::string>
+subscription_handler::supported_search_params() const {
+    return {{"_id", "Resource ID"},
+            {"status", "Subscription status"},
+            {"criteria", "Subscription criteria (partial match)"}};
+}
+
+bool subscription_handler::supports_interaction(
+    interaction_type type) const noexcept {
+    switch (type) {
+        case interaction_type::read:
+        case interaction_type::create:
+        case interaction_type::update:
+        case interaction_type::delete_resource:
+        case interaction_type::search:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::vector<interaction_type>
+subscription_handler::supported_interactions() const {
+    return {interaction_type::read,
+            interaction_type::create,
+            interaction_type::update,
+            interaction_type::delete_resource,
+            interaction_type::search};
+}
+
+}  // namespace pacs::bridge::fhir

--- a/src/fhir/subscription_resource.cpp
+++ b/src/fhir/subscription_resource.cpp
@@ -1,0 +1,616 @@
+/**
+ * @file subscription_resource.cpp
+ * @brief FHIR Subscription resource implementation
+ *
+ * Implements the Subscription resource for FHIR R4.
+ *
+ * @see include/pacs/bridge/fhir/subscription_resource.h
+ * @see https://github.com/kcenon/pacs_bridge/issues/36
+ */
+
+#include "pacs/bridge/fhir/subscription_resource.h"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace pacs::bridge::fhir {
+
+// =============================================================================
+// JSON Utilities
+// =============================================================================
+
+namespace {
+
+std::string json_escape(std::string_view input) {
+    std::string result;
+    result.reserve(input.size() + 10);
+
+    for (char c : input) {
+        switch (c) {
+            case '"':
+                result += "\\\"";
+                break;
+            case '\\':
+                result += "\\\\";
+                break;
+            case '\b':
+                result += "\\b";
+                break;
+            case '\f':
+                result += "\\f";
+                break;
+            case '\n':
+                result += "\\n";
+                break;
+            case '\r':
+                result += "\\r";
+                break;
+            case '\t':
+                result += "\\t";
+                break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char buf[8];
+                    snprintf(buf, sizeof(buf), "\\u%04x",
+                             static_cast<unsigned int>(c));
+                    result += buf;
+                } else {
+                    result += c;
+                }
+                break;
+        }
+    }
+    return result;
+}
+
+std::string to_lower(std::string_view str) {
+    std::string result;
+    result.reserve(str.size());
+    for (char c : str) {
+        result += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return result;
+}
+
+std::string extract_json_string(const std::string& json, const std::string& key) {
+    std::string search = "\"" + key + "\"";
+    auto pos = json.find(search);
+    if (pos == std::string::npos) {
+        return "";
+    }
+
+    pos += search.size();
+
+    while (pos < json.size() &&
+           (std::isspace(static_cast<unsigned char>(json[pos])) ||
+            json[pos] == ':')) {
+        ++pos;
+    }
+
+    if (pos >= json.size() || json[pos] != '"') {
+        return "";
+    }
+    ++pos;
+
+    std::string result;
+    while (pos < json.size() && json[pos] != '"') {
+        if (json[pos] == '\\' && pos + 1 < json.size()) {
+            ++pos;
+            switch (json[pos]) {
+                case 'n':
+                    result += '\n';
+                    break;
+                case 'r':
+                    result += '\r';
+                    break;
+                case 't':
+                    result += '\t';
+                    break;
+                case '"':
+                    result += '"';
+                    break;
+                case '\\':
+                    result += '\\';
+                    break;
+                default:
+                    result += json[pos];
+                    break;
+            }
+        } else {
+            result += json[pos];
+        }
+        ++pos;
+    }
+
+    return result;
+}
+
+std::vector<std::string> extract_json_string_array(
+    const std::string& json,
+    const std::string& key) {
+    std::vector<std::string> result;
+
+    std::string search = "\"" + key + "\"";
+    auto pos = json.find(search);
+    if (pos == std::string::npos) {
+        return result;
+    }
+
+    pos += search.size();
+
+    while (pos < json.size() &&
+           (std::isspace(static_cast<unsigned char>(json[pos])) ||
+            json[pos] == ':')) {
+        ++pos;
+    }
+
+    if (pos >= json.size() || json[pos] != '[') {
+        return result;
+    }
+    ++pos;
+
+    while (pos < json.size() && json[pos] != ']') {
+        while (pos < json.size() && std::isspace(static_cast<unsigned char>(json[pos]))) {
+            ++pos;
+        }
+
+        if (pos < json.size() && json[pos] == '"') {
+            ++pos;
+            std::string value;
+            while (pos < json.size() && json[pos] != '"') {
+                if (json[pos] == '\\' && pos + 1 < json.size()) {
+                    ++pos;
+                    value += json[pos];
+                } else {
+                    value += json[pos];
+                }
+                ++pos;
+            }
+            ++pos;
+            result.push_back(value);
+        }
+
+        while (pos < json.size() &&
+               (std::isspace(static_cast<unsigned char>(json[pos])) || json[pos] == ',')) {
+            ++pos;
+        }
+    }
+
+    return result;
+}
+
+}  // namespace
+
+// =============================================================================
+// Subscription Status
+// =============================================================================
+
+std::optional<subscription_status> parse_subscription_status(
+    std::string_view status_str) noexcept {
+    std::string lower = to_lower(status_str);
+
+    if (lower == "requested") {
+        return subscription_status::requested;
+    }
+    if (lower == "active") {
+        return subscription_status::active;
+    }
+    if (lower == "error") {
+        return subscription_status::error;
+    }
+    if (lower == "off") {
+        return subscription_status::off;
+    }
+
+    return std::nullopt;
+}
+
+// =============================================================================
+// Subscription Channel Type
+// =============================================================================
+
+std::optional<subscription_channel_type> parse_channel_type(
+    std::string_view type_str) noexcept {
+    std::string lower = to_lower(type_str);
+
+    if (lower == "rest-hook") {
+        return subscription_channel_type::rest_hook;
+    }
+    if (lower == "websocket") {
+        return subscription_channel_type::websocket;
+    }
+    if (lower == "email") {
+        return subscription_channel_type::email;
+    }
+    if (lower == "message") {
+        return subscription_channel_type::message;
+    }
+
+    return std::nullopt;
+}
+
+// =============================================================================
+// Delivery Status
+// =============================================================================
+
+std::optional<delivery_status> parse_delivery_status(
+    std::string_view status_str) noexcept {
+    std::string lower = to_lower(status_str);
+
+    if (lower == "pending") {
+        return delivery_status::pending;
+    }
+    if (lower == "in-progress") {
+        return delivery_status::in_progress;
+    }
+    if (lower == "completed") {
+        return delivery_status::completed;
+    }
+    if (lower == "failed") {
+        return delivery_status::failed;
+    }
+    if (lower == "abandoned") {
+        return delivery_status::abandoned;
+    }
+
+    return std::nullopt;
+}
+
+// =============================================================================
+// Subscription Resource Implementation
+// =============================================================================
+
+class subscription_resource::impl {
+public:
+    subscription_status status = subscription_status::requested;
+    std::vector<std::string> contacts;
+    std::optional<std::string> end;
+    std::optional<std::string> reason;
+    std::string criteria;
+    std::optional<std::string> error;
+    subscription_channel channel;
+};
+
+subscription_resource::subscription_resource() : pimpl_(std::make_unique<impl>()) {}
+
+subscription_resource::~subscription_resource() = default;
+
+subscription_resource::subscription_resource(subscription_resource&&) noexcept = default;
+
+subscription_resource& subscription_resource::operator=(subscription_resource&&) noexcept =
+    default;
+
+resource_type subscription_resource::type() const noexcept {
+    return resource_type::subscription;
+}
+
+std::string subscription_resource::type_name() const { return "Subscription"; }
+
+std::string subscription_resource::to_json() const {
+    std::ostringstream json;
+    json << "{\n";
+    json << "  \"resourceType\": \"Subscription\"";
+
+    // ID
+    if (!id().empty()) {
+        json << ",\n  \"id\": \"" << json_escape(id()) << "\"";
+    }
+
+    // Status (required)
+    json << ",\n  \"status\": \"" << to_string(pimpl_->status) << "\"";
+
+    // Contact
+    if (!pimpl_->contacts.empty()) {
+        json << ",\n  \"contact\": [\n";
+        for (size_t i = 0; i < pimpl_->contacts.size(); ++i) {
+            json << "    {\n";
+            json << "      \"system\": \"email\",\n";
+            json << "      \"value\": \"" << json_escape(pimpl_->contacts[i]) << "\"\n";
+            json << "    }";
+            if (i < pimpl_->contacts.size() - 1) {
+                json << ",";
+            }
+            json << "\n";
+        }
+        json << "  ]";
+    }
+
+    // End
+    if (pimpl_->end.has_value()) {
+        json << ",\n  \"end\": \"" << json_escape(*pimpl_->end) << "\"";
+    }
+
+    // Reason
+    if (pimpl_->reason.has_value()) {
+        json << ",\n  \"reason\": \"" << json_escape(*pimpl_->reason) << "\"";
+    }
+
+    // Criteria (required)
+    json << ",\n  \"criteria\": \"" << json_escape(pimpl_->criteria) << "\"";
+
+    // Error
+    if (pimpl_->error.has_value()) {
+        json << ",\n  \"error\": \"" << json_escape(*pimpl_->error) << "\"";
+    }
+
+    // Channel (required)
+    json << ",\n  \"channel\": {\n";
+    json << "    \"type\": \"" << to_string(pimpl_->channel.type) << "\"";
+    json << ",\n    \"endpoint\": \"" << json_escape(pimpl_->channel.endpoint) << "\"";
+
+    if (pimpl_->channel.payload.has_value()) {
+        json << ",\n    \"payload\": \"" << json_escape(*pimpl_->channel.payload) << "\"";
+    }
+
+    if (!pimpl_->channel.header.empty()) {
+        json << ",\n    \"header\": [";
+        for (size_t i = 0; i < pimpl_->channel.header.size(); ++i) {
+            if (i > 0) {
+                json << ", ";
+            }
+            json << "\"" << json_escape(pimpl_->channel.header[i]) << "\"";
+        }
+        json << "]";
+    }
+
+    json << "\n  }";
+
+    json << "\n}";
+    return json.str();
+}
+
+bool subscription_resource::validate() const {
+    // Required: status, criteria, channel.type, channel.endpoint
+    if (pimpl_->criteria.empty()) {
+        return false;
+    }
+    if (pimpl_->channel.endpoint.empty()) {
+        return false;
+    }
+    return true;
+}
+
+void subscription_resource::set_status(subscription_status status) {
+    pimpl_->status = status;
+}
+
+subscription_status subscription_resource::status() const noexcept {
+    return pimpl_->status;
+}
+
+void subscription_resource::add_contact(const std::string& contact) {
+    pimpl_->contacts.push_back(contact);
+}
+
+const std::vector<std::string>& subscription_resource::contacts() const noexcept {
+    return pimpl_->contacts;
+}
+
+void subscription_resource::clear_contacts() {
+    pimpl_->contacts.clear();
+}
+
+void subscription_resource::set_end(std::string datetime) {
+    pimpl_->end = std::move(datetime);
+}
+
+const std::optional<std::string>& subscription_resource::end() const noexcept {
+    return pimpl_->end;
+}
+
+void subscription_resource::set_reason(std::string reason) {
+    pimpl_->reason = std::move(reason);
+}
+
+const std::optional<std::string>& subscription_resource::reason() const noexcept {
+    return pimpl_->reason;
+}
+
+void subscription_resource::set_criteria(std::string criteria) {
+    pimpl_->criteria = std::move(criteria);
+}
+
+const std::string& subscription_resource::criteria() const noexcept {
+    return pimpl_->criteria;
+}
+
+void subscription_resource::set_error(std::string error) {
+    pimpl_->error = std::move(error);
+}
+
+const std::optional<std::string>& subscription_resource::error() const noexcept {
+    return pimpl_->error;
+}
+
+void subscription_resource::set_channel(const subscription_channel& channel) {
+    pimpl_->channel = channel;
+}
+
+const subscription_channel& subscription_resource::channel() const noexcept {
+    return pimpl_->channel;
+}
+
+std::unique_ptr<subscription_resource> subscription_resource::from_json(
+    const std::string& json) {
+    std::string resource_type_str = extract_json_string(json, "resourceType");
+    if (resource_type_str != "Subscription") {
+        return nullptr;
+    }
+
+    auto subscription = std::make_unique<subscription_resource>();
+
+    // Extract id
+    std::string id_str = extract_json_string(json, "id");
+    if (!id_str.empty()) {
+        subscription->set_id(std::move(id_str));
+    }
+
+    // Extract status
+    std::string status_str = extract_json_string(json, "status");
+    if (!status_str.empty()) {
+        auto status = parse_subscription_status(status_str);
+        if (status.has_value()) {
+            subscription->set_status(*status);
+        }
+    }
+
+    // Extract end
+    std::string end_str = extract_json_string(json, "end");
+    if (!end_str.empty()) {
+        subscription->set_end(std::move(end_str));
+    }
+
+    // Extract reason
+    std::string reason_str = extract_json_string(json, "reason");
+    if (!reason_str.empty()) {
+        subscription->set_reason(std::move(reason_str));
+    }
+
+    // Extract criteria
+    std::string criteria_str = extract_json_string(json, "criteria");
+    if (!criteria_str.empty()) {
+        subscription->set_criteria(std::move(criteria_str));
+    }
+
+    // Extract error
+    std::string error_str = extract_json_string(json, "error");
+    if (!error_str.empty()) {
+        subscription->set_error(std::move(error_str));
+    }
+
+    // Extract channel
+    subscription_channel channel;
+
+    // Find channel object
+    auto channel_pos = json.find("\"channel\"");
+    if (channel_pos != std::string::npos) {
+        auto brace_pos = json.find('{', channel_pos);
+        if (brace_pos != std::string::npos) {
+            auto end_brace = json.find('}', brace_pos);
+            if (end_brace != std::string::npos) {
+                std::string channel_json = json.substr(brace_pos, end_brace - brace_pos + 1);
+
+                std::string type_str = extract_json_string(channel_json, "type");
+                if (!type_str.empty()) {
+                    auto type = parse_channel_type(type_str);
+                    if (type.has_value()) {
+                        channel.type = *type;
+                    }
+                }
+
+                channel.endpoint = extract_json_string(channel_json, "endpoint");
+
+                std::string payload_str = extract_json_string(channel_json, "payload");
+                if (!payload_str.empty()) {
+                    channel.payload = payload_str;
+                }
+
+                channel.header = extract_json_string_array(channel_json, "header");
+            }
+        }
+    }
+
+    subscription->set_channel(channel);
+
+    return subscription;
+}
+
+// =============================================================================
+// Criteria Parsing
+// =============================================================================
+
+std::optional<parsed_criteria> parse_subscription_criteria(
+    std::string_view criteria) noexcept {
+    if (criteria.empty()) {
+        return std::nullopt;
+    }
+
+    parsed_criteria result;
+
+    // Find '?' separator
+    auto query_pos = criteria.find('?');
+    if (query_pos == std::string_view::npos) {
+        // No query parameters, just resource type
+        result.resource_type = std::string(criteria);
+        return result;
+    }
+
+    result.resource_type = std::string(criteria.substr(0, query_pos));
+
+    // Parse query parameters
+    std::string_view query = criteria.substr(query_pos + 1);
+
+    size_t pos = 0;
+    while (pos < query.size()) {
+        // Find '=' separator
+        auto eq_pos = query.find('=', pos);
+        if (eq_pos == std::string_view::npos) {
+            break;
+        }
+
+        std::string key(query.substr(pos, eq_pos - pos));
+
+        // Find '&' separator or end
+        auto amp_pos = query.find('&', eq_pos + 1);
+        std::string value;
+        if (amp_pos == std::string_view::npos) {
+            value = std::string(query.substr(eq_pos + 1));
+            pos = query.size();
+        } else {
+            value = std::string(query.substr(eq_pos + 1, amp_pos - eq_pos - 1));
+            pos = amp_pos + 1;
+        }
+
+        if (!key.empty()) {
+            result.params[key] = value;
+        }
+    }
+
+    return result;
+}
+
+bool matches_criteria(
+    const fhir_resource& resource,
+    const parsed_criteria& criteria) {
+    // Check resource type
+    if (resource.type_name() != criteria.resource_type) {
+        return false;
+    }
+
+    // If no parameters, match all resources of this type
+    if (criteria.params.empty()) {
+        return true;
+    }
+
+    // Check specific parameters based on resource type
+    // This is a simplified implementation - full implementation would
+    // need to parse the resource JSON and check each parameter
+
+    std::string resource_json = resource.to_json();
+
+    for (const auto& [key, value] : criteria.params) {
+        // Special handling for status parameter
+        if (key == "status") {
+            std::string status_str = extract_json_string(resource_json, "status");
+            if (status_str != value) {
+                return false;
+            }
+        }
+        // Other parameters would need specific handling
+        // For now, we do a simple substring search as a fallback
+        else {
+            std::string search_key = "\"" + key + "\"";
+            std::string search_value = "\"" + value + "\"";
+            if (resource_json.find(search_key) != std::string::npos) {
+                if (resource_json.find(search_value) == std::string::npos) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+}  // namespace pacs::bridge::fhir

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -385,6 +385,9 @@ if(BRIDGE_BUILD_FHIR)
 
     # FHIR-DICOM Mapper Tests (Phase 3 - Issue #35)
     add_gtest_test(fhir_dicom_mapper_test "unit;fhir;mapping;phase3")
+
+    # Subscription Tests (Phase 3 - Issue #36)
+    add_bridge_test(subscription_test "unit;fhir;subscription;phase3")
 endif()
 
 # =============================================================================
@@ -440,6 +443,7 @@ if(BRIDGE_BUILD_FHIR)
     message(STATUS "  - service_request_resource_test")
     message(STATUS "  - imaging_study_resource_test")
     message(STATUS "  - fhir_dicom_mapper_test")
+    message(STATUS "  - subscription_test")
 endif()
 message(STATUS "==========================")
 message(STATUS "")

--- a/tests/subscription_test.cpp
+++ b/tests/subscription_test.cpp
@@ -1,0 +1,756 @@
+/**
+ * @file subscription_test.cpp
+ * @brief Unit tests for FHIR Subscription resource and manager
+ *
+ * Tests cover:
+ * - Subscription resource creation and serialization
+ * - Subscription status and channel type parsing
+ * - Criteria parsing and matching
+ * - Subscription storage (in-memory)
+ * - Subscription manager CRUD operations
+ * - Subscription handler integration
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/36
+ */
+
+#include "pacs/bridge/fhir/subscription_resource.h"
+#include "pacs/bridge/fhir/subscription_manager.h"
+#include "pacs/bridge/fhir/imaging_study_resource.h"
+
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace pacs::bridge::fhir::test {
+
+// =============================================================================
+// Test Utilities
+// =============================================================================
+
+#define TEST_ASSERT(condition, message)                                        \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            std::cerr << "FAILED: " << message << " at " << __FILE__ << ":"    \
+                      << __LINE__ << std::endl;                                \
+            return false;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define RUN_TEST(test_fn)                                                      \
+    do {                                                                       \
+        std::cout << "Running " << #test_fn << "... ";                         \
+        if (test_fn()) {                                                       \
+            std::cout << "PASSED" << std::endl;                                \
+            passed++;                                                          \
+        } else {                                                               \
+            std::cout << "FAILED" << std::endl;                                \
+            failed++;                                                          \
+        }                                                                      \
+    } while (0)
+
+// =============================================================================
+// Subscription Status Tests
+// =============================================================================
+
+bool test_subscription_status_to_string() {
+    TEST_ASSERT(to_string(subscription_status::requested) == "requested",
+                "requested status string");
+    TEST_ASSERT(to_string(subscription_status::active) == "active",
+                "active status string");
+    TEST_ASSERT(to_string(subscription_status::error) == "error",
+                "error status string");
+    TEST_ASSERT(to_string(subscription_status::off) == "off",
+                "off status string");
+    return true;
+}
+
+bool test_subscription_status_parsing() {
+    auto requested = parse_subscription_status("requested");
+    TEST_ASSERT(requested.has_value() &&
+                *requested == subscription_status::requested,
+                "parse requested");
+
+    auto active = parse_subscription_status("ACTIVE");
+    TEST_ASSERT(active.has_value() && *active == subscription_status::active,
+                "parse ACTIVE (uppercase)");
+
+    auto off = parse_subscription_status("off");
+    TEST_ASSERT(off.has_value() && *off == subscription_status::off,
+                "parse off");
+
+    auto invalid = parse_subscription_status("invalid");
+    TEST_ASSERT(!invalid.has_value(), "invalid status returns nullopt");
+
+    return true;
+}
+
+// =============================================================================
+// Channel Type Tests
+// =============================================================================
+
+bool test_channel_type_to_string() {
+    TEST_ASSERT(to_string(subscription_channel_type::rest_hook) == "rest-hook",
+                "rest-hook channel string");
+    TEST_ASSERT(to_string(subscription_channel_type::websocket) == "websocket",
+                "websocket channel string");
+    TEST_ASSERT(to_string(subscription_channel_type::email) == "email",
+                "email channel string");
+    TEST_ASSERT(to_string(subscription_channel_type::message) == "message",
+                "message channel string");
+    return true;
+}
+
+bool test_channel_type_parsing() {
+    auto rest_hook = parse_channel_type("rest-hook");
+    TEST_ASSERT(rest_hook.has_value() &&
+                *rest_hook == subscription_channel_type::rest_hook,
+                "parse rest-hook");
+
+    auto websocket = parse_channel_type("WEBSOCKET");
+    TEST_ASSERT(websocket.has_value() &&
+                *websocket == subscription_channel_type::websocket,
+                "parse WEBSOCKET (uppercase)");
+
+    auto invalid = parse_channel_type("invalid");
+    TEST_ASSERT(!invalid.has_value(), "invalid channel type returns nullopt");
+
+    return true;
+}
+
+// =============================================================================
+// Subscription Resource Tests
+// =============================================================================
+
+bool test_subscription_resource_creation() {
+    subscription_resource sub;
+    sub.set_id("sub-123");
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("ImagingStudy?status=available");
+    sub.set_reason("Monitor for completed studies");
+
+    subscription_channel channel;
+    channel.type = subscription_channel_type::rest_hook;
+    channel.endpoint = "https://emr.hospital.local/fhir-notify";
+    channel.payload = "application/fhir+json";
+    channel.header.push_back("Authorization: Bearer token123");
+    sub.set_channel(channel);
+
+    TEST_ASSERT(sub.id() == "sub-123", "subscription ID");
+    TEST_ASSERT(sub.status() == subscription_status::active, "subscription status");
+    TEST_ASSERT(sub.criteria() == "ImagingStudy?status=available",
+                "subscription criteria");
+    TEST_ASSERT(sub.reason().has_value() &&
+                *sub.reason() == "Monitor for completed studies",
+                "subscription reason");
+    TEST_ASSERT(sub.channel().type == subscription_channel_type::rest_hook,
+                "channel type");
+    TEST_ASSERT(sub.channel().endpoint == "https://emr.hospital.local/fhir-notify",
+                "channel endpoint");
+    TEST_ASSERT(sub.channel().payload.has_value() &&
+                *sub.channel().payload == "application/fhir+json",
+                "channel payload");
+    TEST_ASSERT(sub.channel().header.size() == 1, "channel header count");
+
+    return true;
+}
+
+bool test_subscription_resource_type() {
+    subscription_resource sub;
+
+    TEST_ASSERT(sub.type() == resource_type::subscription, "resource type enum");
+    TEST_ASSERT(sub.type_name() == "Subscription", "resource type name");
+
+    return true;
+}
+
+bool test_subscription_resource_validation() {
+    subscription_resource valid_sub;
+    valid_sub.set_criteria("ImagingStudy?status=available");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com/notify";
+    valid_sub.set_channel(channel);
+
+    TEST_ASSERT(valid_sub.validate(), "valid subscription validates");
+
+    subscription_resource invalid_sub;
+    // Missing criteria and endpoint
+    TEST_ASSERT(!invalid_sub.validate(), "invalid subscription fails validation");
+
+    return true;
+}
+
+bool test_subscription_resource_json_serialization() {
+    subscription_resource sub;
+    sub.set_id("sub-456");
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("DiagnosticReport?status=final");
+    sub.set_reason("Report notifications");
+
+    subscription_channel channel;
+    channel.type = subscription_channel_type::rest_hook;
+    channel.endpoint = "https://ris.hospital.local/notify";
+    channel.payload = "application/fhir+json";
+    sub.set_channel(channel);
+
+    std::string json = sub.to_json();
+
+    TEST_ASSERT(json.find("\"resourceType\": \"Subscription\"") != std::string::npos,
+                "JSON contains resourceType");
+    TEST_ASSERT(json.find("\"id\": \"sub-456\"") != std::string::npos,
+                "JSON contains id");
+    TEST_ASSERT(json.find("\"status\": \"active\"") != std::string::npos,
+                "JSON contains status");
+    TEST_ASSERT(json.find("\"criteria\": \"DiagnosticReport?status=final\"") != std::string::npos,
+                "JSON contains criteria");
+    TEST_ASSERT(json.find("\"channel\"") != std::string::npos,
+                "JSON contains channel");
+    TEST_ASSERT(json.find("\"type\": \"rest-hook\"") != std::string::npos,
+                "JSON contains channel type");
+    TEST_ASSERT(json.find("\"endpoint\"") != std::string::npos,
+                "JSON contains endpoint");
+
+    return true;
+}
+
+bool test_subscription_resource_json_parsing() {
+    std::string json = R"({
+        "resourceType": "Subscription",
+        "id": "sub-789",
+        "status": "active",
+        "criteria": "ImagingStudy?status=available",
+        "reason": "Study monitoring",
+        "channel": {
+            "type": "rest-hook",
+            "endpoint": "https://notify.example.com",
+            "payload": "application/fhir+json"
+        }
+    })";
+
+    auto sub = subscription_resource::from_json(json);
+
+    TEST_ASSERT(sub != nullptr, "parsing succeeds");
+    TEST_ASSERT(sub->id() == "sub-789", "parsed ID");
+    TEST_ASSERT(sub->status() == subscription_status::active, "parsed status");
+    TEST_ASSERT(sub->criteria() == "ImagingStudy?status=available", "parsed criteria");
+    TEST_ASSERT(sub->reason().has_value() && *sub->reason() == "Study monitoring",
+                "parsed reason");
+    TEST_ASSERT(sub->channel().type == subscription_channel_type::rest_hook,
+                "parsed channel type");
+    TEST_ASSERT(sub->channel().endpoint == "https://notify.example.com",
+                "parsed endpoint");
+
+    return true;
+}
+
+// =============================================================================
+// Criteria Parsing Tests
+// =============================================================================
+
+bool test_criteria_parsing_simple() {
+    auto criteria = parse_subscription_criteria("ImagingStudy");
+
+    TEST_ASSERT(criteria.has_value(), "parsing simple criteria succeeds");
+    TEST_ASSERT(criteria->resource_type == "ImagingStudy", "resource type extracted");
+    TEST_ASSERT(criteria->params.empty(), "no parameters");
+
+    return true;
+}
+
+bool test_criteria_parsing_with_params() {
+    auto criteria = parse_subscription_criteria("ImagingStudy?status=available");
+
+    TEST_ASSERT(criteria.has_value(), "parsing criteria with params succeeds");
+    TEST_ASSERT(criteria->resource_type == "ImagingStudy", "resource type extracted");
+    TEST_ASSERT(criteria->params.size() == 1, "one parameter");
+    TEST_ASSERT(criteria->params.count("status") == 1, "status param exists");
+    TEST_ASSERT(criteria->params.at("status") == "available", "status param value");
+
+    return true;
+}
+
+bool test_criteria_parsing_multiple_params() {
+    auto criteria = parse_subscription_criteria(
+        "DiagnosticReport?status=final&patient=Patient/123");
+
+    TEST_ASSERT(criteria.has_value(), "parsing multiple params succeeds");
+    TEST_ASSERT(criteria->resource_type == "DiagnosticReport", "resource type");
+    TEST_ASSERT(criteria->params.size() == 2, "two parameters");
+    TEST_ASSERT(criteria->params.at("status") == "final", "status param");
+    TEST_ASSERT(criteria->params.at("patient") == "Patient/123", "patient param");
+
+    return true;
+}
+
+bool test_criteria_parsing_empty() {
+    auto criteria = parse_subscription_criteria("");
+
+    TEST_ASSERT(!criteria.has_value(), "empty criteria returns nullopt");
+
+    return true;
+}
+
+// =============================================================================
+// Criteria Matching Tests
+// =============================================================================
+
+bool test_criteria_matching_type_only() {
+    imaging_study_resource study;
+    study.set_id("study-123");
+    study.set_status(imaging_study_status::available);
+
+    auto criteria = parse_subscription_criteria("ImagingStudy");
+    TEST_ASSERT(criteria.has_value(), "criteria parsed");
+
+    TEST_ASSERT(matches_criteria(study, *criteria),
+                "study matches type-only criteria");
+
+    return true;
+}
+
+bool test_criteria_matching_with_status() {
+    imaging_study_resource study;
+    study.set_id("study-456");
+    study.set_status(imaging_study_status::available);
+
+    auto match_criteria = parse_subscription_criteria("ImagingStudy?status=available");
+    TEST_ASSERT(match_criteria.has_value(), "match criteria parsed");
+
+    TEST_ASSERT(matches_criteria(study, *match_criteria),
+                "study matches status=available criteria");
+
+    auto no_match_criteria = parse_subscription_criteria("ImagingStudy?status=cancelled");
+    TEST_ASSERT(no_match_criteria.has_value(), "no-match criteria parsed");
+
+    TEST_ASSERT(!matches_criteria(study, *no_match_criteria),
+                "study does not match status=cancelled criteria");
+
+    return true;
+}
+
+bool test_criteria_matching_type_mismatch() {
+    imaging_study_resource study;
+    study.set_id("study-789");
+
+    auto criteria = parse_subscription_criteria("DiagnosticReport");
+    TEST_ASSERT(criteria.has_value(), "criteria parsed");
+
+    TEST_ASSERT(!matches_criteria(study, *criteria),
+                "ImagingStudy does not match DiagnosticReport criteria");
+
+    return true;
+}
+
+// =============================================================================
+// Storage Tests
+// =============================================================================
+
+bool test_in_memory_storage_crud() {
+    in_memory_subscription_storage storage;
+
+    // Create subscription
+    subscription_resource sub;
+    sub.set_id("sub-storage-1");
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("ImagingStudy?status=available");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com/notify";
+    sub.set_channel(channel);
+
+    // Store
+    TEST_ASSERT(storage.store("sub-storage-1", sub), "store succeeds");
+
+    // Get
+    auto retrieved = storage.get("sub-storage-1");
+    TEST_ASSERT(retrieved != nullptr, "retrieval succeeds");
+    TEST_ASSERT(retrieved->id() == "sub-storage-1", "retrieved ID matches");
+    TEST_ASSERT(retrieved->status() == subscription_status::active,
+                "retrieved status matches");
+
+    // Update
+    sub.set_status(subscription_status::off);
+    TEST_ASSERT(storage.update("sub-storage-1", sub), "update succeeds");
+
+    auto updated = storage.get("sub-storage-1");
+    TEST_ASSERT(updated != nullptr, "updated retrieval succeeds");
+    TEST_ASSERT(updated->status() == subscription_status::off,
+                "updated status matches");
+
+    // Remove
+    TEST_ASSERT(storage.remove("sub-storage-1"), "remove succeeds");
+    TEST_ASSERT(storage.get("sub-storage-1") == nullptr,
+                "removed subscription not found");
+
+    return true;
+}
+
+bool test_in_memory_storage_get_active() {
+    in_memory_subscription_storage storage;
+
+    // Create multiple subscriptions
+    subscription_resource sub1;
+    sub1.set_id("sub-active-1");
+    sub1.set_status(subscription_status::active);
+    sub1.set_criteria("ImagingStudy");
+    subscription_channel channel1;
+    channel1.endpoint = "https://example.com/1";
+    sub1.set_channel(channel1);
+    storage.store("sub-active-1", sub1);
+
+    subscription_resource sub2;
+    sub2.set_id("sub-off-1");
+    sub2.set_status(subscription_status::off);
+    sub2.set_criteria("ImagingStudy");
+    subscription_channel channel2;
+    channel2.endpoint = "https://example.com/2";
+    sub2.set_channel(channel2);
+    storage.store("sub-off-1", sub2);
+
+    subscription_resource sub3;
+    sub3.set_id("sub-active-2");
+    sub3.set_status(subscription_status::active);
+    sub3.set_criteria("DiagnosticReport");
+    subscription_channel channel3;
+    channel3.endpoint = "https://example.com/3";
+    sub3.set_channel(channel3);
+    storage.store("sub-active-2", sub3);
+
+    // Get active subscriptions
+    auto active = storage.get_active();
+    TEST_ASSERT(active.size() == 2, "two active subscriptions");
+
+    return true;
+}
+
+bool test_in_memory_storage_get_by_resource_type() {
+    in_memory_subscription_storage storage;
+
+    subscription_resource sub1;
+    sub1.set_id("sub-imaging-1");
+    sub1.set_status(subscription_status::active);
+    sub1.set_criteria("ImagingStudy?status=available");
+    subscription_channel channel1;
+    channel1.endpoint = "https://example.com/1";
+    sub1.set_channel(channel1);
+    storage.store("sub-imaging-1", sub1);
+
+    subscription_resource sub2;
+    sub2.set_id("sub-report-1");
+    sub2.set_status(subscription_status::active);
+    sub2.set_criteria("DiagnosticReport?status=final");
+    subscription_channel channel2;
+    channel2.endpoint = "https://example.com/2";
+    sub2.set_channel(channel2);
+    storage.store("sub-report-1", sub2);
+
+    // Get by resource type
+    auto imaging_subs = storage.get_by_resource_type("ImagingStudy");
+    TEST_ASSERT(imaging_subs.size() == 1, "one ImagingStudy subscription");
+    TEST_ASSERT(imaging_subs[0]->id() == "sub-imaging-1", "correct subscription");
+
+    auto report_subs = storage.get_by_resource_type("DiagnosticReport");
+    TEST_ASSERT(report_subs.size() == 1, "one DiagnosticReport subscription");
+
+    auto patient_subs = storage.get_by_resource_type("Patient");
+    TEST_ASSERT(patient_subs.empty(), "no Patient subscriptions");
+
+    return true;
+}
+
+// =============================================================================
+// Manager Tests
+// =============================================================================
+
+bool test_manager_create_subscription() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    delivery_config config;
+    config.enabled = false;  // Disable delivery for testing
+    subscription_manager manager(storage, config);
+
+    subscription_resource sub;
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("ImagingStudy?status=available");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com/notify";
+    sub.set_channel(channel);
+
+    auto result = manager.create_subscription(sub);
+
+    TEST_ASSERT(is_success(result), "create succeeds");
+
+    const auto& created = get_resource(result);
+    TEST_ASSERT(!created->id().empty(), "ID assigned");
+    TEST_ASSERT(created->status() == subscription_status::active, "status preserved");
+    TEST_ASSERT(created->criteria() == "ImagingStudy?status=available",
+                "criteria preserved");
+
+    return true;
+}
+
+bool test_manager_get_subscription() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    delivery_config config;
+    config.enabled = false;
+    subscription_manager manager(storage, config);
+
+    // Create subscription
+    subscription_resource sub;
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("ImagingStudy");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com";
+    sub.set_channel(channel);
+
+    auto create_result = manager.create_subscription(sub);
+    TEST_ASSERT(is_success(create_result), "create succeeds");
+
+    std::string id = get_resource(create_result)->id();
+
+    // Get subscription
+    auto get_result = manager.get_subscription(id);
+    TEST_ASSERT(is_success(get_result), "get succeeds");
+    TEST_ASSERT(get_resource(get_result)->id() == id, "ID matches");
+
+    // Get non-existent
+    auto not_found = manager.get_subscription("non-existent");
+    TEST_ASSERT(!is_success(not_found), "get non-existent fails");
+
+    return true;
+}
+
+bool test_manager_update_subscription() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    delivery_config config;
+    config.enabled = false;
+    subscription_manager manager(storage, config);
+
+    // Create subscription
+    subscription_resource sub;
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("ImagingStudy");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com";
+    sub.set_channel(channel);
+
+    auto create_result = manager.create_subscription(sub);
+    TEST_ASSERT(is_success(create_result), "create succeeds");
+
+    std::string id = get_resource(create_result)->id();
+
+    // Update subscription
+    subscription_resource updated_sub;
+    updated_sub.set_status(subscription_status::off);
+    updated_sub.set_criteria("ImagingStudy");
+    updated_sub.set_channel(channel);
+
+    auto update_result = manager.update_subscription(id, updated_sub);
+    TEST_ASSERT(is_success(update_result), "update succeeds");
+    TEST_ASSERT(get_resource(update_result)->status() == subscription_status::off,
+                "status updated");
+    TEST_ASSERT(get_resource(update_result)->version_id() == "2",
+                "version incremented");
+
+    return true;
+}
+
+bool test_manager_delete_subscription() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    delivery_config config;
+    config.enabled = false;
+    subscription_manager manager(storage, config);
+
+    // Create subscription
+    subscription_resource sub;
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("ImagingStudy");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com";
+    sub.set_channel(channel);
+
+    auto create_result = manager.create_subscription(sub);
+    TEST_ASSERT(is_success(create_result), "create succeeds");
+
+    std::string id = get_resource(create_result)->id();
+
+    // Delete subscription
+    auto delete_result = manager.delete_subscription(id);
+    TEST_ASSERT(is_success(delete_result), "delete succeeds");
+
+    // Verify deleted
+    auto get_result = manager.get_subscription(id);
+    TEST_ASSERT(!is_success(get_result), "get after delete fails");
+
+    return true;
+}
+
+bool test_manager_statistics() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    delivery_config config;
+    config.enabled = false;
+    subscription_manager manager(storage, config);
+
+    // Create active subscription
+    subscription_resource sub;
+    sub.set_status(subscription_status::active);
+    sub.set_criteria("ImagingStudy");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com";
+    sub.set_channel(channel);
+
+    auto result = manager.create_subscription(sub);
+    TEST_ASSERT(is_success(result), "create succeeds");
+
+    auto stats = manager.get_statistics();
+    TEST_ASSERT(stats.active_subscriptions == 1, "one active subscription");
+
+    return true;
+}
+
+// =============================================================================
+// Handler Tests
+// =============================================================================
+
+bool test_handler_type_info() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    auto manager = std::make_shared<subscription_manager>(storage);
+    subscription_handler handler(manager);
+
+    TEST_ASSERT(handler.handled_type() == resource_type::subscription,
+                "handled type is subscription");
+    TEST_ASSERT(handler.type_name() == "Subscription", "type name is Subscription");
+
+    return true;
+}
+
+bool test_handler_supported_interactions() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    auto manager = std::make_shared<subscription_manager>(storage);
+    subscription_handler handler(manager);
+
+    TEST_ASSERT(handler.supports_interaction(interaction_type::read),
+                "supports read");
+    TEST_ASSERT(handler.supports_interaction(interaction_type::create),
+                "supports create");
+    TEST_ASSERT(handler.supports_interaction(interaction_type::update),
+                "supports update");
+    TEST_ASSERT(handler.supports_interaction(interaction_type::delete_resource),
+                "supports delete");
+    TEST_ASSERT(handler.supports_interaction(interaction_type::search),
+                "supports search");
+    TEST_ASSERT(!handler.supports_interaction(interaction_type::vread),
+                "does not support vread");
+
+    return true;
+}
+
+bool test_handler_search() {
+    auto storage = std::make_shared<in_memory_subscription_storage>();
+    auto manager = std::make_shared<subscription_manager>(storage);
+    subscription_handler handler(manager);
+
+    // Create subscriptions
+    subscription_resource sub1;
+    sub1.set_status(subscription_status::active);
+    sub1.set_criteria("ImagingStudy");
+    subscription_channel channel;
+    channel.endpoint = "https://example.com";
+    sub1.set_channel(channel);
+    manager->create_subscription(sub1);
+
+    subscription_resource sub2;
+    sub2.set_status(subscription_status::off);
+    sub2.set_criteria("DiagnosticReport");
+    sub2.set_channel(channel);
+    manager->create_subscription(sub2);
+
+    // Search all
+    std::map<std::string, std::string> empty_params;
+    pagination_params pagination;
+    auto all_result = handler.search(empty_params, pagination);
+
+    TEST_ASSERT(is_success(all_result), "search all succeeds");
+    TEST_ASSERT(get_resource(all_result).total == 2, "found 2 subscriptions");
+
+    // Search by status
+    std::map<std::string, std::string> status_params = {{"status", "active"}};
+    auto active_result = handler.search(status_params, pagination);
+
+    TEST_ASSERT(is_success(active_result), "search by status succeeds");
+    TEST_ASSERT(get_resource(active_result).total == 1, "found 1 active subscription");
+
+    return true;
+}
+
+}  // namespace pacs::bridge::fhir::test
+
+// =============================================================================
+// Main
+// =============================================================================
+
+int main() {
+    using namespace pacs::bridge::fhir::test;
+
+    int passed = 0;
+    int failed = 0;
+
+    std::cout << "=== FHIR Subscription Tests ===" << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- Status Tests ---" << std::endl;
+    RUN_TEST(test_subscription_status_to_string);
+    RUN_TEST(test_subscription_status_parsing);
+    std::cout << std::endl;
+
+    std::cout << "--- Channel Type Tests ---" << std::endl;
+    RUN_TEST(test_channel_type_to_string);
+    RUN_TEST(test_channel_type_parsing);
+    std::cout << std::endl;
+
+    std::cout << "--- Subscription Resource Tests ---" << std::endl;
+    RUN_TEST(test_subscription_resource_creation);
+    RUN_TEST(test_subscription_resource_type);
+    RUN_TEST(test_subscription_resource_validation);
+    RUN_TEST(test_subscription_resource_json_serialization);
+    RUN_TEST(test_subscription_resource_json_parsing);
+    std::cout << std::endl;
+
+    std::cout << "--- Criteria Parsing Tests ---" << std::endl;
+    RUN_TEST(test_criteria_parsing_simple);
+    RUN_TEST(test_criteria_parsing_with_params);
+    RUN_TEST(test_criteria_parsing_multiple_params);
+    RUN_TEST(test_criteria_parsing_empty);
+    std::cout << std::endl;
+
+    std::cout << "--- Criteria Matching Tests ---" << std::endl;
+    RUN_TEST(test_criteria_matching_type_only);
+    RUN_TEST(test_criteria_matching_with_status);
+    RUN_TEST(test_criteria_matching_type_mismatch);
+    std::cout << std::endl;
+
+    std::cout << "--- Storage Tests ---" << std::endl;
+    RUN_TEST(test_in_memory_storage_crud);
+    RUN_TEST(test_in_memory_storage_get_active);
+    RUN_TEST(test_in_memory_storage_get_by_resource_type);
+    std::cout << std::endl;
+
+    std::cout << "--- Manager Tests ---" << std::endl;
+    RUN_TEST(test_manager_create_subscription);
+    RUN_TEST(test_manager_get_subscription);
+    RUN_TEST(test_manager_update_subscription);
+    RUN_TEST(test_manager_delete_subscription);
+    RUN_TEST(test_manager_statistics);
+    std::cout << std::endl;
+
+    std::cout << "--- Handler Tests ---" << std::endl;
+    RUN_TEST(test_handler_type_info);
+    RUN_TEST(test_handler_supported_interactions);
+    RUN_TEST(test_handler_search);
+    std::cout << std::endl;
+
+    std::cout << "================================" << std::endl;
+    std::cout << "Results: " << passed << " passed, " << failed << " failed"
+              << std::endl;
+
+    return failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Implement FHIR R4 Subscription resource for event-based notifications
- Add Subscription Manager with REST-hook delivery support
- Add criteria parsing and matching for ImagingStudy and DiagnosticReport events
- Implement in-memory subscription storage with thread-safe operations

## Changes
- `include/pacs/bridge/fhir/subscription_resource.h`: Subscription resource definition
- `include/pacs/bridge/fhir/subscription_manager.h`: Manager and handler interfaces
- `src/fhir/subscription_resource.cpp`: Subscription resource implementation
- `src/fhir/subscription_manager.cpp`: Manager and handler implementation
- `tests/subscription_test.cpp`: 27 unit tests
- Updated `CMakeLists.txt` and `fhir_types.h` to include new resource type

## Test plan
- [x] Run subscription_test: 27/27 tests passing
- [x] Build with FHIR enabled: successful
- [ ] Integration test with actual FHIR server (manual)

## Notes
HTTP client uses stub implementation for testing. For production use, inject a real HTTP client via the `subscription_manager` constructor (supports libcurl, Boost.Beast, etc.).

Closes #36