### PR TITLE
feat(emr): implement EMR adapter interface and tests (#107, #121)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,8 @@ endif()
 # See: https://github.com/kcenon/pacs_bridge/issues/104
 # See: https://github.com/kcenon/pacs_bridge/issues/105
 # See: https://github.com/kcenon/pacs_bridge/issues/106
+# See: https://github.com/kcenon/pacs_bridge/issues/107
+# See: https://github.com/kcenon/pacs_bridge/issues/121
 list(APPEND PACS_BRIDGE_SOURCES
     src/emr/emr_types.cpp
     src/emr/fhir_bundle.cpp
@@ -328,6 +330,8 @@ list(APPEND PACS_BRIDGE_SOURCES
     src/emr/diagnostic_report_builder.cpp
     src/emr/result_tracker.cpp
     src/emr/encounter_context.cpp
+    src/emr/emr_adapter.cpp
+    src/emr/adapters/generic_fhir_adapter.cpp
 )
 list(APPEND PACS_BRIDGE_HEADERS
     include/pacs/bridge/emr/emr_types.h
@@ -342,6 +346,8 @@ list(APPEND PACS_BRIDGE_HEADERS
     include/pacs/bridge/emr/diagnostic_report_builder.h
     include/pacs/bridge/emr/result_tracker.h
     include/pacs/bridge/emr/encounter_context.h
+    include/pacs/bridge/emr/emr_adapter.h
+    include/pacs/bridge/emr/adapters/generic_fhir_adapter.h
 )
 
 # =============================================================================

--- a/include/pacs/bridge/emr/adapters/generic_fhir_adapter.h
+++ b/include/pacs/bridge/emr/adapters/generic_fhir_adapter.h
@@ -1,0 +1,165 @@
+#ifndef PACS_BRIDGE_EMR_ADAPTERS_GENERIC_FHIR_ADAPTER_H
+#define PACS_BRIDGE_EMR_ADAPTERS_GENERIC_FHIR_ADAPTER_H
+
+/**
+ * @file generic_fhir_adapter.h
+ * @brief Generic FHIR R4 EMR adapter implementation
+ *
+ * Provides a standard FHIR R4 compliant adapter that works with any
+ * EMR system supporting the FHIR R4 specification. This serves as
+ * the default adapter and base class for vendor-specific adapters.
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/107
+ * @see https://www.hl7.org/fhir/
+ */
+
+#include "../emr_adapter.h"
+#include "../fhir_client.h"
+
+#include <memory>
+#include <mutex>
+
+namespace pacs::bridge::emr {
+
+/**
+ * @brief Generic FHIR R4 adapter implementation
+ *
+ * Standard FHIR R4 compliant adapter that works with any EMR system
+ * supporting the FHIR R4 specification. Implements the emr_adapter
+ * interface using fhir_client, emr_patient_lookup, and emr_result_poster.
+ *
+ * Thread-safe: All operations are protected by mutex.
+ */
+class generic_fhir_adapter : public emr_adapter {
+public:
+    /**
+     * @brief Construct with configuration
+     *
+     * @param config Adapter configuration
+     */
+    explicit generic_fhir_adapter(const emr_adapter_config& config);
+
+    /**
+     * @brief Construct with existing FHIR client
+     *
+     * @param client FHIR client to use
+     * @param config Adapter configuration
+     */
+    generic_fhir_adapter(std::shared_ptr<fhir_client> client,
+                         const emr_adapter_config& config);
+
+    /**
+     * @brief Destructor
+     */
+    ~generic_fhir_adapter() override;
+
+    // Non-copyable, movable
+    generic_fhir_adapter(const generic_fhir_adapter&) = delete;
+    generic_fhir_adapter& operator=(const generic_fhir_adapter&) = delete;
+    generic_fhir_adapter(generic_fhir_adapter&&) noexcept;
+    generic_fhir_adapter& operator=(generic_fhir_adapter&&) noexcept;
+
+    // =========================================================================
+    // Identification (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] emr_vendor vendor() const noexcept override;
+    [[nodiscard]] std::string_view vendor_name() const noexcept override;
+    [[nodiscard]] std::string_view version() const noexcept override;
+    [[nodiscard]] adapter_features features() const noexcept override;
+
+    // =========================================================================
+    // Connection Management (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] std::expected<void, adapter_error> initialize() override;
+    void shutdown() noexcept override;
+    [[nodiscard]] bool is_initialized() const noexcept override;
+    [[nodiscard]] bool is_connected() const noexcept override;
+
+    // =========================================================================
+    // Health Check (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] std::expected<adapter_health_status, adapter_error>
+    health_check() override;
+
+    [[nodiscard]] adapter_health_status
+    get_health_status() const noexcept override;
+
+    // =========================================================================
+    // Patient Operations (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] std::expected<patient_record, patient_error>
+    query_patient(const patient_query& query) override;
+
+    [[nodiscard]] std::expected<std::vector<patient_match>, patient_error>
+    search_patients(const patient_query& query) override;
+
+    // =========================================================================
+    // Result Operations (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] std::expected<posted_result, result_error>
+    post_result(const study_result& result) override;
+
+    [[nodiscard]] std::expected<void, result_error>
+    update_result(std::string_view report_id,
+                  const study_result& result) override;
+
+    // =========================================================================
+    // Encounter Operations (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] std::expected<encounter_info, encounter_error>
+    get_encounter(std::string_view encounter_id) override;
+
+    [[nodiscard]] std::expected<std::optional<encounter_info>, encounter_error>
+    find_active_encounter(std::string_view patient_id) override;
+
+    // =========================================================================
+    // Configuration (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] const emr_adapter_config& config() const noexcept override;
+
+    [[nodiscard]] std::expected<void, adapter_error>
+    set_config(const emr_adapter_config& config) override;
+
+    // =========================================================================
+    // Statistics (emr_adapter interface)
+    // =========================================================================
+
+    [[nodiscard]] statistics get_statistics() const noexcept override;
+    void reset_statistics() noexcept override;
+
+    // =========================================================================
+    // Generic FHIR Specific Methods
+    // =========================================================================
+
+    /**
+     * @brief Get underlying FHIR client
+     */
+    [[nodiscard]] std::shared_ptr<fhir_client> get_fhir_client() const noexcept;
+
+protected:
+    /**
+     * @brief Create FHIR client from configuration
+     */
+    [[nodiscard]] std::expected<std::shared_ptr<fhir_client>, adapter_error>
+    create_fhir_client();
+
+    /**
+     * @brief Update internal statistics
+     */
+    void record_request(bool success, std::chrono::milliseconds duration);
+
+private:
+    class impl;
+    std::unique_ptr<impl> impl_;
+};
+
+}  // namespace pacs::bridge::emr
+
+#endif  // PACS_BRIDGE_EMR_ADAPTERS_GENERIC_FHIR_ADAPTER_H

--- a/include/pacs/bridge/emr/emr_adapter.h
+++ b/include/pacs/bridge/emr/emr_adapter.h
@@ -1,0 +1,613 @@
+#ifndef PACS_BRIDGE_EMR_EMR_ADAPTER_H
+#define PACS_BRIDGE_EMR_EMR_ADAPTER_H
+
+/**
+ * @file emr_adapter.h
+ * @brief Abstract EMR adapter interface for vendor-specific EMR integration
+ *
+ * Defines a common interface for EMR adapters that can be implemented
+ * for different EMR vendors (Epic, Cerner, generic FHIR R4, etc.).
+ * This abstraction allows PACS Bridge to work with multiple EMR systems
+ * through a unified API.
+ *
+ * Features:
+ *   - Vendor-agnostic interface for patient lookup
+ *   - Result posting to EMR
+ *   - Encounter context retrieval
+ *   - Health check and connection management
+ *   - Factory pattern for adapter creation
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/107
+ * @see https://github.com/kcenon/pacs_bridge/issues/121
+ */
+
+#include "emr_types.h"
+#include "encounter_context.h"
+#include "patient_lookup.h"
+#include "patient_record.h"
+#include "result_poster.h"
+
+#include <chrono>
+#include <expected>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::bridge::emr {
+
+// =============================================================================
+// EMR Adapter Error Codes (-1100 to -1119)
+// =============================================================================
+
+/**
+ * @brief EMR adapter specific error codes
+ *
+ * Allocated range: -1100 to -1119
+ */
+enum class adapter_error : int {
+    /** Adapter not initialized */
+    not_initialized = -1100,
+
+    /** Connection to EMR failed */
+    connection_failed = -1101,
+
+    /** Authentication failed */
+    authentication_failed = -1102,
+
+    /** Operation not supported by this adapter */
+    not_supported = -1103,
+
+    /** Invalid adapter configuration */
+    invalid_configuration = -1104,
+
+    /** Adapter operation timed out */
+    timeout = -1105,
+
+    /** Rate limited by EMR */
+    rate_limited = -1106,
+
+    /** Invalid vendor type */
+    invalid_vendor = -1107,
+
+    /** Health check failed */
+    health_check_failed = -1108,
+
+    /** Feature not available */
+    feature_unavailable = -1109
+};
+
+/**
+ * @brief Convert adapter_error to error code integer
+ */
+[[nodiscard]] constexpr int to_error_code(adapter_error error) noexcept {
+    return static_cast<int>(error);
+}
+
+/**
+ * @brief Get human-readable description of adapter error
+ */
+[[nodiscard]] constexpr const char* to_string(adapter_error error) noexcept {
+    switch (error) {
+        case adapter_error::not_initialized:
+            return "EMR adapter not initialized";
+        case adapter_error::connection_failed:
+            return "Connection to EMR failed";
+        case adapter_error::authentication_failed:
+            return "EMR authentication failed";
+        case adapter_error::not_supported:
+            return "Operation not supported by this adapter";
+        case adapter_error::invalid_configuration:
+            return "Invalid adapter configuration";
+        case adapter_error::timeout:
+            return "EMR operation timed out";
+        case adapter_error::rate_limited:
+            return "Rate limited by EMR system";
+        case adapter_error::invalid_vendor:
+            return "Invalid EMR vendor type";
+        case adapter_error::health_check_failed:
+            return "EMR health check failed";
+        case adapter_error::feature_unavailable:
+            return "Feature not available in this adapter";
+        default:
+            return "Unknown adapter error";
+    }
+}
+
+// =============================================================================
+// EMR Vendor Types
+// =============================================================================
+
+/**
+ * @brief Supported EMR vendor types
+ */
+enum class emr_vendor {
+    /** Generic FHIR R4 compliant EMR (default) */
+    generic_fhir,
+
+    /** Epic EMR (Epic FHIR R4 with extensions) */
+    epic,
+
+    /** Cerner/Oracle Health */
+    cerner,
+
+    /** MEDITECH Expanse */
+    meditech,
+
+    /** Allscripts */
+    allscripts,
+
+    /** Unknown/custom vendor */
+    unknown
+};
+
+/**
+ * @brief Convert emr_vendor to string
+ */
+[[nodiscard]] constexpr std::string_view to_string(emr_vendor vendor) noexcept {
+    switch (vendor) {
+        case emr_vendor::generic_fhir:
+            return "generic";
+        case emr_vendor::epic:
+            return "epic";
+        case emr_vendor::cerner:
+            return "cerner";
+        case emr_vendor::meditech:
+            return "meditech";
+        case emr_vendor::allscripts:
+            return "allscripts";
+        case emr_vendor::unknown:
+        default:
+            return "unknown";
+    }
+}
+
+/**
+ * @brief Parse emr_vendor from string
+ */
+[[nodiscard]] emr_vendor parse_emr_vendor(std::string_view vendor_str) noexcept;
+
+// =============================================================================
+// Adapter Feature Flags
+// =============================================================================
+
+/**
+ * @brief Features that an adapter may support
+ */
+struct adapter_features {
+    /** Supports patient lookup by MRN */
+    bool patient_lookup{true};
+
+    /** Supports patient search (name, DOB, etc.) */
+    bool patient_search{true};
+
+    /** Supports posting DiagnosticReport */
+    bool result_posting{true};
+
+    /** Supports result status updates */
+    bool result_updates{true};
+
+    /** Supports encounter context retrieval */
+    bool encounter_context{true};
+
+    /** Supports ImagingStudy resource */
+    bool imaging_study{true};
+
+    /** Supports ServiceRequest resource */
+    bool service_request{true};
+
+    /** Supports bulk data export */
+    bool bulk_export{false};
+
+    /** Supports SMART on FHIR */
+    bool smart_on_fhir{true};
+
+    /** Supports OAuth2 client credentials */
+    bool oauth2_client_credentials{true};
+
+    /** Supports basic authentication */
+    bool basic_auth{true};
+};
+
+// =============================================================================
+// Adapter Configuration
+// =============================================================================
+
+/**
+ * @brief Configuration for EMR adapter
+ */
+struct emr_adapter_config {
+    /** EMR vendor type */
+    emr_vendor vendor{emr_vendor::generic_fhir};
+
+    /** FHIR server base URL */
+    std::string base_url;
+
+    /** Authentication type (oauth2, basic, smart) */
+    std::string auth_type{"oauth2"};
+
+    /** OAuth2 client ID (if applicable) */
+    std::optional<std::string> client_id;
+
+    /** OAuth2 client secret (if applicable) */
+    std::optional<std::string> client_secret;
+
+    /** OAuth2 token URL (if applicable) */
+    std::optional<std::string> token_url;
+
+    /** OAuth2 scopes (if applicable) */
+    std::vector<std::string> scopes;
+
+    /** Basic auth username (if applicable) */
+    std::optional<std::string> username;
+
+    /** Basic auth password (if applicable) */
+    std::optional<std::string> password;
+
+    /** Connection timeout */
+    std::chrono::seconds timeout{30};
+
+    /** Default identifier system for MRN */
+    std::optional<std::string> mrn_system;
+
+    /** Organization identifier */
+    std::optional<std::string> organization_id;
+
+    /** Enable strict FHIR validation */
+    bool strict_mode{false};
+
+    /** Retry policy */
+    retry_policy retry;
+
+    // Vendor-specific configuration
+
+    /** Epic: non-production environment flag */
+    bool epic_non_production{false};
+
+    /** Cerner: tenant ID */
+    std::optional<std::string> cerner_tenant_id;
+
+    /**
+     * @brief Validate configuration
+     */
+    [[nodiscard]] bool is_valid() const noexcept {
+        if (base_url.empty()) {
+            return false;
+        }
+        if (auth_type == "oauth2") {
+            if (!client_id.has_value() || !token_url.has_value()) {
+                return false;
+            }
+        } else if (auth_type == "basic") {
+            if (!username.has_value()) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+// =============================================================================
+// Adapter Health Status
+// =============================================================================
+
+/**
+ * @brief Health status of an EMR adapter
+ */
+struct adapter_health_status {
+    /** Whether the adapter is healthy */
+    bool healthy{false};
+
+    /** Connection to EMR server established */
+    bool connected{false};
+
+    /** Authentication is valid */
+    bool authenticated{false};
+
+    /** Last successful health check time */
+    std::optional<std::chrono::system_clock::time_point> last_check;
+
+    /** Error message if unhealthy */
+    std::optional<std::string> error_message;
+
+    /** Response time of last health check */
+    std::chrono::milliseconds response_time{0};
+
+    /** FHIR server version (if available) */
+    std::optional<std::string> server_version;
+
+    /** Supported FHIR resources (from CapabilityStatement) */
+    std::vector<std::string> supported_resources;
+};
+
+// =============================================================================
+// EMR Adapter Interface
+// =============================================================================
+
+/**
+ * @brief Abstract interface for EMR adapters
+ *
+ * Provides a vendor-agnostic interface for EMR operations.
+ * Concrete implementations handle vendor-specific details.
+ *
+ * Thread-safe: All operations are thread-safe for concurrent use.
+ *
+ * @example Basic Usage
+ * ```cpp
+ * // Create adapter using factory
+ * emr_adapter_config config;
+ * config.vendor = emr_vendor::generic_fhir;
+ * config.base_url = "https://emr.hospital.local/fhir";
+ * config.auth_type = "oauth2";
+ * config.client_id = "pacs_bridge";
+ * config.token_url = "https://emr.hospital.local/oauth/token";
+ *
+ * auto adapter = create_emr_adapter(config);
+ *
+ * // Query patient
+ * auto query = patient_query::by_mrn("MRN12345");
+ * auto result = adapter->query_patient(query);
+ * if (result) {
+ *     std::cout << "Patient: " << result->family_name() << "\n";
+ * }
+ *
+ * // Post result
+ * study_result sr;
+ * sr.study_instance_uid = "1.2.3.4.5";
+ * sr.patient_id = "MRN12345";
+ * sr.modality = "CT";
+ * sr.study_datetime = "2025-01-15T10:30:00Z";
+ *
+ * auto post = adapter->post_result(sr);
+ * ```
+ */
+class emr_adapter {
+public:
+    /**
+     * @brief Virtual destructor
+     */
+    virtual ~emr_adapter() = default;
+
+    // =========================================================================
+    // Identification
+    // =========================================================================
+
+    /**
+     * @brief Get the vendor type of this adapter
+     */
+    [[nodiscard]] virtual emr_vendor vendor() const noexcept = 0;
+
+    /**
+     * @brief Get the vendor name as string
+     */
+    [[nodiscard]] virtual std::string_view vendor_name() const noexcept = 0;
+
+    /**
+     * @brief Get the adapter version
+     */
+    [[nodiscard]] virtual std::string_view version() const noexcept = 0;
+
+    /**
+     * @brief Get supported features
+     */
+    [[nodiscard]] virtual adapter_features features() const noexcept = 0;
+
+    // =========================================================================
+    // Connection Management
+    // =========================================================================
+
+    /**
+     * @brief Initialize the adapter
+     *
+     * Must be called before using other operations.
+     *
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, adapter_error> initialize() = 0;
+
+    /**
+     * @brief Shutdown the adapter
+     *
+     * Releases resources and closes connections.
+     */
+    virtual void shutdown() noexcept = 0;
+
+    /**
+     * @brief Check if the adapter is initialized
+     */
+    [[nodiscard]] virtual bool is_initialized() const noexcept = 0;
+
+    /**
+     * @brief Check if the adapter is connected
+     */
+    [[nodiscard]] virtual bool is_connected() const noexcept = 0;
+
+    // =========================================================================
+    // Health Check
+    // =========================================================================
+
+    /**
+     * @brief Perform health check
+     *
+     * @return Health status or error
+     */
+    [[nodiscard]] virtual std::expected<adapter_health_status, adapter_error>
+    health_check() = 0;
+
+    /**
+     * @brief Get current health status (cached)
+     */
+    [[nodiscard]] virtual adapter_health_status
+    get_health_status() const noexcept = 0;
+
+    // =========================================================================
+    // Patient Operations
+    // =========================================================================
+
+    /**
+     * @brief Query patient by various criteria
+     *
+     * @param query Patient query parameters
+     * @return Patient record or error
+     */
+    [[nodiscard]] virtual std::expected<patient_record, patient_error>
+    query_patient(const patient_query& query) = 0;
+
+    /**
+     * @brief Search for patients matching criteria
+     *
+     * @param query Search query
+     * @return List of matching patients or error
+     */
+    [[nodiscard]] virtual std::expected<std::vector<patient_match>, patient_error>
+    search_patients(const patient_query& query) = 0;
+
+    // =========================================================================
+    // Result Operations
+    // =========================================================================
+
+    /**
+     * @brief Post imaging result to EMR
+     *
+     * Creates a DiagnosticReport resource in the EMR.
+     *
+     * @param result Study result data
+     * @return Posted result reference or error
+     */
+    [[nodiscard]] virtual std::expected<posted_result, result_error>
+    post_result(const study_result& result) = 0;
+
+    /**
+     * @brief Update existing result in EMR
+     *
+     * @param report_id DiagnosticReport resource ID
+     * @param result Updated result data
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, result_error>
+    update_result(std::string_view report_id,
+                  const study_result& result) = 0;
+
+    // =========================================================================
+    // Encounter Operations
+    // =========================================================================
+
+    /**
+     * @brief Get encounter by ID
+     *
+     * @param encounter_id Encounter resource ID
+     * @return Encounter info or error
+     */
+    [[nodiscard]] virtual std::expected<encounter_info, encounter_error>
+    get_encounter(std::string_view encounter_id) = 0;
+
+    /**
+     * @brief Find active encounter for patient
+     *
+     * @param patient_id Patient ID or reference
+     * @return Active encounter (if exists) or error
+     */
+    [[nodiscard]] virtual std::expected<std::optional<encounter_info>,
+                                        encounter_error>
+    find_active_encounter(std::string_view patient_id) = 0;
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    /**
+     * @brief Get current configuration
+     */
+    [[nodiscard]] virtual const emr_adapter_config& config() const noexcept = 0;
+
+    /**
+     * @brief Update configuration
+     *
+     * May require re-initialization.
+     *
+     * @param config New configuration
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, adapter_error>
+    set_config(const emr_adapter_config& config) = 0;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    /**
+     * @brief Adapter statistics
+     */
+    struct statistics {
+        size_t total_requests{0};
+        size_t successful_requests{0};
+        size_t failed_requests{0};
+        size_t patient_queries{0};
+        size_t result_posts{0};
+        size_t encounter_queries{0};
+        std::chrono::milliseconds total_request_time{0};
+        std::chrono::milliseconds avg_response_time{0};
+    };
+
+    /**
+     * @brief Get adapter statistics
+     */
+    [[nodiscard]] virtual statistics get_statistics() const noexcept = 0;
+
+    /**
+     * @brief Reset statistics
+     */
+    virtual void reset_statistics() noexcept = 0;
+
+protected:
+    // Prevent direct instantiation
+    emr_adapter() = default;
+    emr_adapter(const emr_adapter&) = default;
+    emr_adapter& operator=(const emr_adapter&) = default;
+    emr_adapter(emr_adapter&&) = default;
+    emr_adapter& operator=(emr_adapter&&) = default;
+};
+
+// =============================================================================
+// Factory Function
+// =============================================================================
+
+/**
+ * @brief Create an EMR adapter based on configuration
+ *
+ * Factory function that creates the appropriate adapter implementation
+ * based on the vendor type specified in the configuration.
+ *
+ * @param config Adapter configuration
+ * @return Unique pointer to adapter or error
+ *
+ * @example
+ * ```cpp
+ * emr_adapter_config config;
+ * config.vendor = emr_vendor::generic_fhir;
+ * config.base_url = "https://fhir.example.com";
+ *
+ * auto result = create_emr_adapter(config);
+ * if (result) {
+ *     auto& adapter = *result;
+ *     adapter->initialize();
+ * }
+ * ```
+ */
+[[nodiscard]] std::expected<std::unique_ptr<emr_adapter>, adapter_error>
+create_emr_adapter(const emr_adapter_config& config);
+
+/**
+ * @brief Create an EMR adapter with specific vendor type
+ *
+ * @param vendor Vendor type
+ * @param base_url FHIR server base URL
+ * @return Unique pointer to adapter or error
+ */
+[[nodiscard]] std::expected<std::unique_ptr<emr_adapter>, adapter_error>
+create_emr_adapter(emr_vendor vendor, std::string_view base_url);
+
+}  // namespace pacs::bridge::emr
+
+#endif  // PACS_BRIDGE_EMR_EMR_ADAPTER_H

--- a/src/emr/CMakeLists.txt
+++ b/src/emr/CMakeLists.txt
@@ -5,6 +5,8 @@
 # See: https://github.com/kcenon/pacs_bridge/issues/104
 # See: https://github.com/kcenon/pacs_bridge/issues/105
 # See: https://github.com/kcenon/pacs_bridge/issues/106
+# See: https://github.com/kcenon/pacs_bridge/issues/107
+# See: https://github.com/kcenon/pacs_bridge/issues/121
 
 add_library(pacs_bridge_emr STATIC
     emr_types.cpp
@@ -18,6 +20,8 @@ add_library(pacs_bridge_emr STATIC
     diagnostic_report_builder.cpp
     result_tracker.cpp
     encounter_context.cpp
+    emr_adapter.cpp
+    adapters/generic_fhir_adapter.cpp
 )
 
 target_include_directories(pacs_bridge_emr PUBLIC

--- a/src/emr/adapters/generic_fhir_adapter.cpp
+++ b/src/emr/adapters/generic_fhir_adapter.cpp
@@ -1,0 +1,547 @@
+/**
+ * @file generic_fhir_adapter.cpp
+ * @brief Generic FHIR R4 EMR adapter implementation
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/107
+ */
+
+#include "pacs/bridge/emr/adapters/generic_fhir_adapter.h"
+#include "pacs/bridge/emr/encounter_context.h"
+#include "pacs/bridge/emr/patient_lookup.h"
+#include "pacs/bridge/emr/result_poster.h"
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+
+namespace pacs::bridge::emr {
+
+// =============================================================================
+// Implementation Class
+// =============================================================================
+
+class generic_fhir_adapter::impl {
+public:
+    explicit impl(const emr_adapter_config& config)
+        : config_(config)
+        , initialized_(false)
+        , connected_(false) {}
+
+    impl(std::shared_ptr<fhir_client> client, const emr_adapter_config& config)
+        : config_(config)
+        , fhir_client_(std::move(client))
+        , initialized_(false)
+        , connected_(false) {}
+
+    ~impl() = default;
+
+    // Non-copyable, non-movable (contains mutex and atomic)
+    impl(const impl&) = delete;
+    impl& operator=(const impl&) = delete;
+    impl(impl&&) = delete;
+    impl& operator=(impl&&) = delete;
+
+    // Configuration
+    emr_adapter_config config_;
+
+    // Services
+    std::shared_ptr<fhir_client> fhir_client_;
+    std::unique_ptr<emr_patient_lookup> patient_lookup_;
+    std::unique_ptr<emr_result_poster> result_poster_;
+    std::unique_ptr<encounter_context_provider> encounter_provider_;
+
+    // State
+    std::atomic<bool> initialized_;
+    std::atomic<bool> connected_;
+    adapter_health_status health_status_;
+    emr_adapter::statistics stats_;
+
+    // Synchronization
+    mutable std::mutex mutex_;
+    mutable std::mutex stats_mutex_;
+};
+
+// =============================================================================
+// Constructor / Destructor
+// =============================================================================
+
+generic_fhir_adapter::generic_fhir_adapter(const emr_adapter_config& config)
+    : impl_(std::make_unique<impl>(config)) {}
+
+generic_fhir_adapter::generic_fhir_adapter(
+    std::shared_ptr<fhir_client> client,
+    const emr_adapter_config& config)
+    : impl_(std::make_unique<impl>(std::move(client), config)) {}
+
+generic_fhir_adapter::~generic_fhir_adapter() {
+    shutdown();
+}
+
+generic_fhir_adapter::generic_fhir_adapter(generic_fhir_adapter&&) noexcept = default;
+generic_fhir_adapter& generic_fhir_adapter::operator=(generic_fhir_adapter&&) noexcept = default;
+
+// =============================================================================
+// Identification
+// =============================================================================
+
+emr_vendor generic_fhir_adapter::vendor() const noexcept {
+    return emr_vendor::generic_fhir;
+}
+
+std::string_view generic_fhir_adapter::vendor_name() const noexcept {
+    return "Generic FHIR R4";
+}
+
+std::string_view generic_fhir_adapter::version() const noexcept {
+    return "1.0.0";
+}
+
+adapter_features generic_fhir_adapter::features() const noexcept {
+    adapter_features f;
+    f.patient_lookup = true;
+    f.patient_search = true;
+    f.result_posting = true;
+    f.result_updates = true;
+    f.encounter_context = true;
+    f.imaging_study = true;
+    f.service_request = true;
+    f.bulk_export = false;  // Not yet implemented
+    f.smart_on_fhir = true;
+    f.oauth2_client_credentials = true;
+    f.basic_auth = true;
+    return f;
+}
+
+// =============================================================================
+// Connection Management
+// =============================================================================
+
+std::expected<void, adapter_error> generic_fhir_adapter::initialize() {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+
+    if (impl_->initialized_) {
+        return {};  // Already initialized
+    }
+
+    // Validate configuration
+    if (!impl_->config_.is_valid()) {
+        return std::unexpected(adapter_error::invalid_configuration);
+    }
+
+    // Create FHIR client if not provided
+    if (!impl_->fhir_client_) {
+        auto result = create_fhir_client();
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+        impl_->fhir_client_ = *result;
+    }
+
+    // Create patient lookup service
+    patient_lookup_config lookup_config;
+    lookup_config.enable_cache = true;
+    if (impl_->config_.mrn_system.has_value()) {
+        lookup_config.default_identifier_system = *impl_->config_.mrn_system;
+    }
+    impl_->patient_lookup_ = std::make_unique<emr_patient_lookup>(
+        impl_->fhir_client_, lookup_config);
+
+    // Create result poster service
+    result_poster_config poster_config;
+    poster_config.check_duplicates = true;
+    poster_config.enable_tracking = true;
+    if (impl_->config_.organization_id.has_value()) {
+        poster_config.issuing_organization = *impl_->config_.organization_id;
+    }
+    impl_->result_poster_ = std::make_unique<emr_result_poster>(
+        impl_->fhir_client_, poster_config);
+
+    // Create encounter provider
+    encounter_context_config encounter_config;
+    encounter_config.client = impl_->fhir_client_;
+    encounter_config.include_location = true;
+    encounter_config.include_participants = true;
+    impl_->encounter_provider_ = std::make_unique<encounter_context_provider>(
+        encounter_config);
+
+    impl_->initialized_ = true;
+    impl_->connected_ = true;
+
+    return {};
+}
+
+void generic_fhir_adapter::shutdown() noexcept {
+    if (!impl_) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+
+    impl_->encounter_provider_.reset();
+    impl_->result_poster_.reset();
+    impl_->patient_lookup_.reset();
+    impl_->fhir_client_.reset();
+
+    impl_->initialized_ = false;
+    impl_->connected_ = false;
+}
+
+bool generic_fhir_adapter::is_initialized() const noexcept {
+    return impl_ && impl_->initialized_;
+}
+
+bool generic_fhir_adapter::is_connected() const noexcept {
+    return impl_ && impl_->connected_;
+}
+
+// =============================================================================
+// Health Check
+// =============================================================================
+
+std::expected<adapter_health_status, adapter_error>
+generic_fhir_adapter::health_check() {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+
+    if (!impl_->initialized_) {
+        return std::unexpected(adapter_error::not_initialized);
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    adapter_health_status status;
+
+    // Try to get capabilities from FHIR server
+    auto cap_result = impl_->fhir_client_->capabilities();
+    auto end = std::chrono::steady_clock::now();
+
+    status.response_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end - start);
+    status.last_check = std::chrono::system_clock::now();
+
+    if (cap_result) {
+        status.healthy = true;
+        status.connected = true;
+        status.authenticated = true;
+        impl_->connected_ = true;
+    } else {
+        status.healthy = false;
+        status.connected = false;
+        status.error_message = to_string(cap_result.error());
+        impl_->connected_ = false;
+    }
+
+    impl_->health_status_ = status;
+    return status;
+}
+
+adapter_health_status generic_fhir_adapter::get_health_status() const noexcept {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->health_status_;
+}
+
+// =============================================================================
+// Patient Operations
+// =============================================================================
+
+std::expected<patient_record, patient_error>
+generic_fhir_adapter::query_patient(const patient_query& query) {
+    auto start = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex_);
+        if (!impl_->initialized_) {
+            return std::unexpected(patient_error::query_failed);
+        }
+    }
+
+    auto result = impl_->patient_lookup_->find_patient(query);
+
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.total_requests++;
+        impl_->stats_.patient_queries++;
+        impl_->stats_.total_request_time += duration;
+        if (result) {
+            impl_->stats_.successful_requests++;
+        } else {
+            impl_->stats_.failed_requests++;
+        }
+    }
+
+    return result;
+}
+
+std::expected<std::vector<patient_match>, patient_error>
+generic_fhir_adapter::search_patients(const patient_query& query) {
+    auto start = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex_);
+        if (!impl_->initialized_) {
+            return std::unexpected(patient_error::query_failed);
+        }
+    }
+
+    auto result = impl_->patient_lookup_->search_patients(query);
+
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.total_requests++;
+        impl_->stats_.patient_queries++;
+        impl_->stats_.total_request_time += duration;
+        if (result) {
+            impl_->stats_.successful_requests++;
+        } else {
+            impl_->stats_.failed_requests++;
+        }
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Result Operations
+// =============================================================================
+
+std::expected<posted_result, result_error>
+generic_fhir_adapter::post_result(const study_result& result) {
+    auto start = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex_);
+        if (!impl_->initialized_) {
+            return std::unexpected(result_error::post_failed);
+        }
+    }
+
+    auto post_result = impl_->result_poster_->post_result(result);
+
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.total_requests++;
+        impl_->stats_.result_posts++;
+        impl_->stats_.total_request_time += duration;
+        if (post_result) {
+            impl_->stats_.successful_requests++;
+        } else {
+            impl_->stats_.failed_requests++;
+        }
+    }
+
+    return post_result;
+}
+
+std::expected<void, result_error>
+generic_fhir_adapter::update_result(std::string_view report_id,
+                                    const study_result& result) {
+    auto start = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex_);
+        if (!impl_->initialized_) {
+            return std::unexpected(result_error::update_failed);
+        }
+    }
+
+    auto update_result = impl_->result_poster_->update_result(report_id, result);
+
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.total_requests++;
+        impl_->stats_.total_request_time += duration;
+        if (update_result) {
+            impl_->stats_.successful_requests++;
+        } else {
+            impl_->stats_.failed_requests++;
+        }
+    }
+
+    return update_result;
+}
+
+// =============================================================================
+// Encounter Operations
+// =============================================================================
+
+std::expected<encounter_info, encounter_error>
+generic_fhir_adapter::get_encounter(std::string_view encounter_id) {
+    auto start = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex_);
+        if (!impl_->initialized_) {
+            return std::unexpected(encounter_error::query_failed);
+        }
+    }
+
+    auto result = impl_->encounter_provider_->get_encounter(encounter_id);
+
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.total_requests++;
+        impl_->stats_.encounter_queries++;
+        impl_->stats_.total_request_time += duration;
+    }
+
+    // Convert variant to expected
+    if (auto* enc = std::get_if<encounter_info>(&result)) {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.successful_requests++;
+        return *enc;
+    } else {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.failed_requests++;
+        return std::unexpected(std::get<encounter_error>(result));
+    }
+}
+
+std::expected<std::optional<encounter_info>, encounter_error>
+generic_fhir_adapter::find_active_encounter(std::string_view patient_id) {
+    auto start = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->mutex_);
+        if (!impl_->initialized_) {
+            return std::unexpected(encounter_error::query_failed);
+        }
+    }
+
+    auto result = impl_->encounter_provider_->find_active_encounter(patient_id);
+
+    auto end = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.total_requests++;
+        impl_->stats_.encounter_queries++;
+        impl_->stats_.total_request_time += duration;
+    }
+
+    // Convert variant to expected
+    if (auto* opt_enc = std::get_if<std::optional<encounter_info>>(&result)) {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.successful_requests++;
+        return *opt_enc;
+    } else {
+        std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+        impl_->stats_.failed_requests++;
+        return std::unexpected(std::get<encounter_error>(result));
+    }
+}
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+const emr_adapter_config& generic_fhir_adapter::config() const noexcept {
+    return impl_->config_;
+}
+
+std::expected<void, adapter_error>
+generic_fhir_adapter::set_config(const emr_adapter_config& config) {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+
+    if (!config.is_valid()) {
+        return std::unexpected(adapter_error::invalid_configuration);
+    }
+
+    // If already initialized, need to reinitialize
+    bool was_initialized = impl_->initialized_;
+    if (was_initialized) {
+        impl_->initialized_ = false;
+        impl_->connected_ = false;
+        impl_->fhir_client_.reset();
+        impl_->patient_lookup_.reset();
+        impl_->result_poster_.reset();
+        impl_->encounter_provider_.reset();
+    }
+
+    impl_->config_ = config;
+
+    // Reinitialize if was running
+    if (was_initialized) {
+        // Unlock before calling initialize to avoid deadlock
+        // But we need to ensure atomicity - use a flag
+        impl_->mutex_.unlock();
+        auto result = initialize();
+        impl_->mutex_.lock();
+        if (!result) {
+            return std::unexpected(result.error());
+        }
+    }
+
+    return {};
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+emr_adapter::statistics generic_fhir_adapter::get_statistics() const noexcept {
+    std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+
+    auto stats = impl_->stats_;
+    if (stats.total_requests > 0) {
+        stats.avg_response_time = std::chrono::milliseconds(
+            stats.total_request_time.count() / stats.total_requests);
+    }
+    return stats;
+}
+
+void generic_fhir_adapter::reset_statistics() noexcept {
+    std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+    impl_->stats_ = {};
+}
+
+// =============================================================================
+// Generic FHIR Specific Methods
+// =============================================================================
+
+std::shared_ptr<fhir_client>
+generic_fhir_adapter::get_fhir_client() const noexcept {
+    std::lock_guard<std::mutex> lock(impl_->mutex_);
+    return impl_->fhir_client_;
+}
+
+std::expected<std::shared_ptr<fhir_client>, adapter_error>
+generic_fhir_adapter::create_fhir_client() {
+    fhir_client_config fhir_config;
+    fhir_config.base_url = impl_->config_.base_url;
+    fhir_config.timeout = impl_->config_.timeout;
+    fhir_config.retry = impl_->config_.retry;
+
+    try {
+        return std::make_shared<fhir_client>(fhir_config);
+    } catch (const std::exception&) {
+        return std::unexpected(adapter_error::connection_failed);
+    }
+}
+
+void generic_fhir_adapter::record_request(bool success,
+                                          std::chrono::milliseconds duration) {
+    std::lock_guard<std::mutex> lock(impl_->stats_mutex_);
+    impl_->stats_.total_requests++;
+    impl_->stats_.total_request_time += duration;
+    if (success) {
+        impl_->stats_.successful_requests++;
+    } else {
+        impl_->stats_.failed_requests++;
+    }
+}
+
+}  // namespace pacs::bridge::emr

--- a/src/emr/emr_adapter.cpp
+++ b/src/emr/emr_adapter.cpp
@@ -1,0 +1,94 @@
+/**
+ * @file emr_adapter.cpp
+ * @brief EMR adapter factory implementation
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/107
+ */
+
+#include "pacs/bridge/emr/emr_adapter.h"
+#include "pacs/bridge/emr/adapters/generic_fhir_adapter.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace pacs::bridge::emr {
+
+// =============================================================================
+// Vendor Parsing
+// =============================================================================
+
+emr_vendor parse_emr_vendor(std::string_view vendor_str) noexcept {
+    // Convert to lowercase for comparison
+    std::string lower;
+    lower.reserve(vendor_str.size());
+    for (char c : vendor_str) {
+        lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+
+    if (lower == "generic" || lower == "generic_fhir" || lower == "fhir") {
+        return emr_vendor::generic_fhir;
+    }
+    if (lower == "epic") {
+        return emr_vendor::epic;
+    }
+    if (lower == "cerner" || lower == "oracle" || lower == "oracle_health") {
+        return emr_vendor::cerner;
+    }
+    if (lower == "meditech") {
+        return emr_vendor::meditech;
+    }
+    if (lower == "allscripts") {
+        return emr_vendor::allscripts;
+    }
+
+    return emr_vendor::unknown;
+}
+
+// =============================================================================
+// Factory Function Implementation
+// =============================================================================
+
+std::expected<std::unique_ptr<emr_adapter>, adapter_error>
+create_emr_adapter(const emr_adapter_config& config) {
+    // Validate configuration
+    if (!config.is_valid()) {
+        return std::unexpected(adapter_error::invalid_configuration);
+    }
+
+    // Create adapter based on vendor
+    switch (config.vendor) {
+        case emr_vendor::generic_fhir:
+            return std::make_unique<generic_fhir_adapter>(config);
+
+        case emr_vendor::epic:
+            // TODO: Epic-specific adapter (Phase 5.2+)
+            // For now, fall through to generic
+            return std::make_unique<generic_fhir_adapter>(config);
+
+        case emr_vendor::cerner:
+            // TODO: Cerner-specific adapter (Phase 5.2+)
+            // For now, fall through to generic
+            return std::make_unique<generic_fhir_adapter>(config);
+
+        case emr_vendor::meditech:
+        case emr_vendor::allscripts:
+            // Not yet implemented
+            return std::unexpected(adapter_error::not_supported);
+
+        case emr_vendor::unknown:
+        default:
+            return std::unexpected(adapter_error::invalid_vendor);
+    }
+}
+
+std::expected<std::unique_ptr<emr_adapter>, adapter_error>
+create_emr_adapter(emr_vendor vendor, std::string_view base_url) {
+    emr_adapter_config config;
+    config.vendor = vendor;
+    config.base_url = std::string(base_url);
+
+    // Minimal config - may need additional setup
+    return create_emr_adapter(config);
+}
+
+}  // namespace pacs::bridge::emr

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -395,7 +395,7 @@ if(BRIDGE_BUILD_FHIR)
 endif()
 
 # =============================================================================
-# Phase 5: EMR Client Tests (Issue #102, #104, #105, #106)
+# Phase 5: EMR Client Tests (Issue #102, #104, #105, #106, #107, #121)
 # =============================================================================
 
 # FHIR R4 Client Tests (Issue #102)
@@ -409,6 +409,9 @@ add_gtest_test(result_poster_test "unit;emr;result;phase5")
 
 # Encounter Context Tests (Issue #106, #120)
 add_gtest_test(encounter_context_test "unit;emr;encounter;phase5")
+
+# EMR Adapter Tests (Issue #107, #121)
+add_gtest_test(emr_adapter_test "unit;emr;adapter;phase5")
 
 # =============================================================================
 # Test Summary
@@ -473,5 +476,6 @@ message(STATUS "  - fhir_client_test")
 message(STATUS "  - patient_lookup_test")
 message(STATUS "  - result_poster_test")
 message(STATUS "  - encounter_context_test")
+message(STATUS "  - emr_adapter_test")
 message(STATUS "==========================")
 message(STATUS "")

--- a/tests/emr_adapter_test.cpp
+++ b/tests/emr_adapter_test.cpp
@@ -1,0 +1,660 @@
+/**
+ * @file emr_adapter_test.cpp
+ * @brief Unit tests for EMR Adapter functionality
+ *
+ * Tests the EMR adapter interface and implementations including:
+ *   - Adapter error codes and strings
+ *   - EMR vendor parsing
+ *   - Adapter configuration validation
+ *   - Adapter features
+ *   - Generic FHIR adapter interface compliance
+ *   - Adapter factory function
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/107
+ * @see https://github.com/kcenon/pacs_bridge/issues/121
+ */
+
+#include <gtest/gtest.h>
+
+#include "pacs/bridge/emr/emr_adapter.h"
+#include "pacs/bridge/emr/adapters/generic_fhir_adapter.h"
+
+#include <chrono>
+#include <string>
+
+using namespace pacs::bridge::emr;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// Adapter Error Tests
+// =============================================================================
+
+class AdapterErrorTest : public ::testing::Test {};
+
+TEST_F(AdapterErrorTest, ErrorCodeValues) {
+    EXPECT_EQ(to_error_code(adapter_error::not_initialized), -1100);
+    EXPECT_EQ(to_error_code(adapter_error::connection_failed), -1101);
+    EXPECT_EQ(to_error_code(adapter_error::authentication_failed), -1102);
+    EXPECT_EQ(to_error_code(adapter_error::not_supported), -1103);
+    EXPECT_EQ(to_error_code(adapter_error::invalid_configuration), -1104);
+    EXPECT_EQ(to_error_code(adapter_error::timeout), -1105);
+    EXPECT_EQ(to_error_code(adapter_error::rate_limited), -1106);
+    EXPECT_EQ(to_error_code(adapter_error::invalid_vendor), -1107);
+    EXPECT_EQ(to_error_code(adapter_error::health_check_failed), -1108);
+    EXPECT_EQ(to_error_code(adapter_error::feature_unavailable), -1109);
+}
+
+TEST_F(AdapterErrorTest, ErrorToString) {
+    EXPECT_STREQ(to_string(adapter_error::not_initialized),
+                 "EMR adapter not initialized");
+    EXPECT_STREQ(to_string(adapter_error::connection_failed),
+                 "Connection to EMR failed");
+    EXPECT_STREQ(to_string(adapter_error::authentication_failed),
+                 "EMR authentication failed");
+    EXPECT_STREQ(to_string(adapter_error::not_supported),
+                 "Operation not supported by this adapter");
+    EXPECT_STREQ(to_string(adapter_error::invalid_configuration),
+                 "Invalid adapter configuration");
+    EXPECT_STREQ(to_string(adapter_error::timeout),
+                 "EMR operation timed out");
+    EXPECT_STREQ(to_string(adapter_error::rate_limited),
+                 "Rate limited by EMR system");
+    EXPECT_STREQ(to_string(adapter_error::invalid_vendor),
+                 "Invalid EMR vendor type");
+}
+
+// =============================================================================
+// EMR Vendor Tests
+// =============================================================================
+
+class EmrVendorTest : public ::testing::Test {};
+
+TEST_F(EmrVendorTest, VendorToString) {
+    EXPECT_EQ(to_string(emr_vendor::generic_fhir), "generic");
+    EXPECT_EQ(to_string(emr_vendor::epic), "epic");
+    EXPECT_EQ(to_string(emr_vendor::cerner), "cerner");
+    EXPECT_EQ(to_string(emr_vendor::meditech), "meditech");
+    EXPECT_EQ(to_string(emr_vendor::allscripts), "allscripts");
+    EXPECT_EQ(to_string(emr_vendor::unknown), "unknown");
+}
+
+TEST_F(EmrVendorTest, ParseVendorGeneric) {
+    EXPECT_EQ(parse_emr_vendor("generic"), emr_vendor::generic_fhir);
+    EXPECT_EQ(parse_emr_vendor("generic_fhir"), emr_vendor::generic_fhir);
+    EXPECT_EQ(parse_emr_vendor("fhir"), emr_vendor::generic_fhir);
+    EXPECT_EQ(parse_emr_vendor("GENERIC"), emr_vendor::generic_fhir);
+    EXPECT_EQ(parse_emr_vendor("Generic"), emr_vendor::generic_fhir);
+}
+
+TEST_F(EmrVendorTest, ParseVendorEpic) {
+    EXPECT_EQ(parse_emr_vendor("epic"), emr_vendor::epic);
+    EXPECT_EQ(parse_emr_vendor("EPIC"), emr_vendor::epic);
+    EXPECT_EQ(parse_emr_vendor("Epic"), emr_vendor::epic);
+}
+
+TEST_F(EmrVendorTest, ParseVendorCerner) {
+    EXPECT_EQ(parse_emr_vendor("cerner"), emr_vendor::cerner);
+    EXPECT_EQ(parse_emr_vendor("oracle"), emr_vendor::cerner);
+    EXPECT_EQ(parse_emr_vendor("oracle_health"), emr_vendor::cerner);
+    EXPECT_EQ(parse_emr_vendor("CERNER"), emr_vendor::cerner);
+}
+
+TEST_F(EmrVendorTest, ParseVendorOther) {
+    EXPECT_EQ(parse_emr_vendor("meditech"), emr_vendor::meditech);
+    EXPECT_EQ(parse_emr_vendor("allscripts"), emr_vendor::allscripts);
+}
+
+TEST_F(EmrVendorTest, ParseVendorUnknown) {
+    EXPECT_EQ(parse_emr_vendor("invalid"), emr_vendor::unknown);
+    EXPECT_EQ(parse_emr_vendor(""), emr_vendor::unknown);
+    EXPECT_EQ(parse_emr_vendor("some_random_vendor"), emr_vendor::unknown);
+}
+
+// =============================================================================
+// Adapter Configuration Tests
+// =============================================================================
+
+class AdapterConfigTest : public ::testing::Test {};
+
+TEST_F(AdapterConfigTest, DefaultConfig) {
+    emr_adapter_config config;
+
+    EXPECT_EQ(config.vendor, emr_vendor::generic_fhir);
+    EXPECT_TRUE(config.base_url.empty());
+    EXPECT_EQ(config.auth_type, "oauth2");
+    EXPECT_FALSE(config.client_id.has_value());
+    EXPECT_FALSE(config.client_secret.has_value());
+    EXPECT_FALSE(config.token_url.has_value());
+    EXPECT_EQ(config.timeout, 30s);
+    EXPECT_FALSE(config.strict_mode);
+    EXPECT_FALSE(config.epic_non_production);
+}
+
+TEST_F(AdapterConfigTest, ValidationEmptyUrl) {
+    emr_adapter_config config;
+    // Empty base_url
+    EXPECT_FALSE(config.is_valid());
+}
+
+TEST_F(AdapterConfigTest, ValidationOAuth2MissingClientId) {
+    emr_adapter_config config;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "oauth2";
+    // Missing client_id
+    EXPECT_FALSE(config.is_valid());
+}
+
+TEST_F(AdapterConfigTest, ValidationOAuth2MissingTokenUrl) {
+    emr_adapter_config config;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "oauth2";
+    config.client_id = "client123";
+    // Missing token_url
+    EXPECT_FALSE(config.is_valid());
+}
+
+TEST_F(AdapterConfigTest, ValidationOAuth2Valid) {
+    emr_adapter_config config;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "oauth2";
+    config.client_id = "client123";
+    config.token_url = "https://emr.example.com/oauth/token";
+
+    EXPECT_TRUE(config.is_valid());
+}
+
+TEST_F(AdapterConfigTest, ValidationBasicAuthMissingUsername) {
+    emr_adapter_config config;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "basic";
+    // Missing username
+    EXPECT_FALSE(config.is_valid());
+}
+
+TEST_F(AdapterConfigTest, ValidationBasicAuthValid) {
+    emr_adapter_config config;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "basic";
+    config.username = "admin";
+    config.password = "secret";
+
+    EXPECT_TRUE(config.is_valid());
+}
+
+TEST_F(AdapterConfigTest, ValidationUnknownAuthType) {
+    emr_adapter_config config;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "none";  // Not oauth2 or basic
+
+    EXPECT_TRUE(config.is_valid());  // Other auth types pass basic validation
+}
+
+// =============================================================================
+// Adapter Features Tests
+// =============================================================================
+
+class AdapterFeaturesTest : public ::testing::Test {};
+
+TEST_F(AdapterFeaturesTest, DefaultFeatures) {
+    adapter_features features;
+
+    EXPECT_TRUE(features.patient_lookup);
+    EXPECT_TRUE(features.patient_search);
+    EXPECT_TRUE(features.result_posting);
+    EXPECT_TRUE(features.result_updates);
+    EXPECT_TRUE(features.encounter_context);
+    EXPECT_TRUE(features.imaging_study);
+    EXPECT_TRUE(features.service_request);
+    EXPECT_FALSE(features.bulk_export);
+    EXPECT_TRUE(features.smart_on_fhir);
+    EXPECT_TRUE(features.oauth2_client_credentials);
+    EXPECT_TRUE(features.basic_auth);
+}
+
+// =============================================================================
+// Adapter Health Status Tests
+// =============================================================================
+
+class AdapterHealthStatusTest : public ::testing::Test {};
+
+TEST_F(AdapterHealthStatusTest, DefaultStatus) {
+    adapter_health_status status;
+
+    EXPECT_FALSE(status.healthy);
+    EXPECT_FALSE(status.connected);
+    EXPECT_FALSE(status.authenticated);
+    EXPECT_FALSE(status.last_check.has_value());
+    EXPECT_FALSE(status.error_message.has_value());
+    EXPECT_EQ(status.response_time, 0ms);
+    EXPECT_FALSE(status.server_version.has_value());
+    EXPECT_TRUE(status.supported_resources.empty());
+}
+
+TEST_F(AdapterHealthStatusTest, HealthyStatus) {
+    adapter_health_status status;
+    status.healthy = true;
+    status.connected = true;
+    status.authenticated = true;
+    status.last_check = std::chrono::system_clock::now();
+    status.response_time = 150ms;
+    status.server_version = "4.0.1";
+    status.supported_resources = {"Patient", "Encounter", "DiagnosticReport"};
+
+    EXPECT_TRUE(status.healthy);
+    EXPECT_TRUE(status.connected);
+    EXPECT_TRUE(status.authenticated);
+    EXPECT_TRUE(status.last_check.has_value());
+    EXPECT_FALSE(status.error_message.has_value());
+    EXPECT_EQ(status.response_time, 150ms);
+    EXPECT_EQ(status.server_version.value(), "4.0.1");
+    EXPECT_EQ(status.supported_resources.size(), 3);
+}
+
+TEST_F(AdapterHealthStatusTest, UnhealthyStatus) {
+    adapter_health_status status;
+    status.healthy = false;
+    status.connected = false;
+    status.error_message = "Connection refused";
+
+    EXPECT_FALSE(status.healthy);
+    EXPECT_FALSE(status.connected);
+    EXPECT_TRUE(status.error_message.has_value());
+    EXPECT_EQ(status.error_message.value(), "Connection refused");
+}
+
+// =============================================================================
+// Generic FHIR Adapter Interface Tests
+// =============================================================================
+
+class GenericFhirAdapterTest : public ::testing::Test {
+protected:
+    emr_adapter_config create_valid_config() {
+        emr_adapter_config config;
+        config.vendor = emr_vendor::generic_fhir;
+        config.base_url = "https://emr.example.com/fhir";
+        config.auth_type = "oauth2";
+        config.client_id = "test_client";
+        config.token_url = "https://emr.example.com/oauth/token";
+        return config;
+    }
+};
+
+TEST_F(GenericFhirAdapterTest, VendorIdentification) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    EXPECT_EQ(adapter.vendor(), emr_vendor::generic_fhir);
+    EXPECT_EQ(adapter.vendor_name(), "Generic FHIR R4");
+    EXPECT_EQ(adapter.version(), "1.0.0");
+}
+
+TEST_F(GenericFhirAdapterTest, DefaultFeatures) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    auto features = adapter.features();
+    EXPECT_TRUE(features.patient_lookup);
+    EXPECT_TRUE(features.patient_search);
+    EXPECT_TRUE(features.result_posting);
+    EXPECT_TRUE(features.encounter_context);
+    EXPECT_FALSE(features.bulk_export);  // Not yet implemented
+}
+
+TEST_F(GenericFhirAdapterTest, NotInitializedByDefault) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    EXPECT_FALSE(adapter.is_initialized());
+    EXPECT_FALSE(adapter.is_connected());
+}
+
+TEST_F(GenericFhirAdapterTest, ConfigAccess) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    const auto& adapter_config = adapter.config();
+    EXPECT_EQ(adapter_config.base_url, "https://emr.example.com/fhir");
+    EXPECT_EQ(adapter_config.vendor, emr_vendor::generic_fhir);
+}
+
+TEST_F(GenericFhirAdapterTest, InitialStatistics) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    auto stats = adapter.get_statistics();
+    EXPECT_EQ(stats.total_requests, 0);
+    EXPECT_EQ(stats.successful_requests, 0);
+    EXPECT_EQ(stats.failed_requests, 0);
+    EXPECT_EQ(stats.patient_queries, 0);
+    EXPECT_EQ(stats.result_posts, 0);
+    EXPECT_EQ(stats.encounter_queries, 0);
+}
+
+TEST_F(GenericFhirAdapterTest, ResetStatistics) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    // Simulate some activity by getting stats multiple times
+    auto stats = adapter.get_statistics();
+    adapter.reset_statistics();
+
+    stats = adapter.get_statistics();
+    EXPECT_EQ(stats.total_requests, 0);
+}
+
+TEST_F(GenericFhirAdapterTest, InitialHealthStatus) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    auto status = adapter.get_health_status();
+    EXPECT_FALSE(status.healthy);
+    EXPECT_FALSE(status.connected);
+}
+
+// =============================================================================
+// Adapter Factory Tests
+// =============================================================================
+
+class AdapterFactoryTest : public ::testing::Test {
+protected:
+    emr_adapter_config create_valid_config(emr_vendor vendor) {
+        emr_adapter_config config;
+        config.vendor = vendor;
+        config.base_url = "https://emr.example.com/fhir";
+        config.auth_type = "oauth2";
+        config.client_id = "test_client";
+        config.token_url = "https://emr.example.com/oauth/token";
+        return config;
+    }
+};
+
+TEST_F(AdapterFactoryTest, CreateGenericAdapter) {
+    auto config = create_valid_config(emr_vendor::generic_fhir);
+
+    auto result = create_emr_adapter(config);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ((*result)->vendor(), emr_vendor::generic_fhir);
+    EXPECT_EQ((*result)->vendor_name(), "Generic FHIR R4");
+}
+
+TEST_F(AdapterFactoryTest, CreateEpicAdapter) {
+    auto config = create_valid_config(emr_vendor::epic);
+
+    auto result = create_emr_adapter(config);
+
+    // Currently falls back to generic
+    ASSERT_TRUE(result.has_value());
+    // Epic adapter will be implemented in Phase 5.2+
+}
+
+TEST_F(AdapterFactoryTest, CreateCernerAdapter) {
+    auto config = create_valid_config(emr_vendor::cerner);
+
+    auto result = create_emr_adapter(config);
+
+    // Currently falls back to generic
+    ASSERT_TRUE(result.has_value());
+    // Cerner adapter will be implemented in Phase 5.2+
+}
+
+TEST_F(AdapterFactoryTest, CreateMeditechAdapter) {
+    auto config = create_valid_config(emr_vendor::meditech);
+
+    auto result = create_emr_adapter(config);
+
+    // Not yet supported
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), adapter_error::not_supported);
+}
+
+TEST_F(AdapterFactoryTest, CreateAllscriptsAdapter) {
+    auto config = create_valid_config(emr_vendor::allscripts);
+
+    auto result = create_emr_adapter(config);
+
+    // Not yet supported
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), adapter_error::not_supported);
+}
+
+TEST_F(AdapterFactoryTest, CreateUnknownVendorAdapter) {
+    auto config = create_valid_config(emr_vendor::unknown);
+
+    auto result = create_emr_adapter(config);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), adapter_error::invalid_vendor);
+}
+
+TEST_F(AdapterFactoryTest, InvalidConfiguration) {
+    emr_adapter_config config;
+    // Empty base_url makes it invalid
+    config.vendor = emr_vendor::generic_fhir;
+
+    auto result = create_emr_adapter(config);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), adapter_error::invalid_configuration);
+}
+
+TEST_F(AdapterFactoryTest, CreateWithVendorAndUrl) {
+    auto result = create_emr_adapter(emr_vendor::generic_fhir,
+                                     "https://emr.example.com/fhir");
+
+    // This will fail because minimal config doesn't have auth
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), adapter_error::invalid_configuration);
+}
+
+// =============================================================================
+// Adapter Interface Compliance Tests
+// =============================================================================
+
+class AdapterInterfaceTest : public ::testing::Test {
+protected:
+    std::unique_ptr<emr_adapter> create_adapter() {
+        emr_adapter_config config;
+        config.vendor = emr_vendor::generic_fhir;
+        config.base_url = "https://emr.example.com/fhir";
+        config.auth_type = "oauth2";
+        config.client_id = "test_client";
+        config.token_url = "https://emr.example.com/oauth/token";
+
+        auto result = create_emr_adapter(config);
+        if (result) {
+            return std::move(*result);
+        }
+        return nullptr;
+    }
+};
+
+TEST_F(AdapterInterfaceTest, VirtualMethodsCalled) {
+    auto adapter = create_adapter();
+    ASSERT_NE(adapter, nullptr);
+
+    // These methods should work via interface
+    EXPECT_EQ(adapter->vendor(), emr_vendor::generic_fhir);
+    EXPECT_FALSE(adapter->vendor_name().empty());
+    EXPECT_FALSE(adapter->version().empty());
+    EXPECT_FALSE(adapter->is_initialized());
+}
+
+TEST_F(AdapterInterfaceTest, StatisticsViaInterface) {
+    auto adapter = create_adapter();
+    ASSERT_NE(adapter, nullptr);
+
+    auto stats = adapter->get_statistics();
+    EXPECT_EQ(stats.total_requests, 0);
+
+    adapter->reset_statistics();
+    stats = adapter->get_statistics();
+    EXPECT_EQ(stats.total_requests, 0);
+}
+
+TEST_F(AdapterInterfaceTest, HealthStatusViaInterface) {
+    auto adapter = create_adapter();
+    ASSERT_NE(adapter, nullptr);
+
+    auto status = adapter->get_health_status();
+    EXPECT_FALSE(status.healthy);
+}
+
+// =============================================================================
+// Configuration Update Tests
+// =============================================================================
+
+class AdapterConfigUpdateTest : public ::testing::Test {
+protected:
+    emr_adapter_config create_valid_config() {
+        emr_adapter_config config;
+        config.vendor = emr_vendor::generic_fhir;
+        config.base_url = "https://emr.example.com/fhir";
+        config.auth_type = "oauth2";
+        config.client_id = "test_client";
+        config.token_url = "https://emr.example.com/oauth/token";
+        return config;
+    }
+};
+
+TEST_F(AdapterConfigUpdateTest, SetConfigInvalidFails) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    emr_adapter_config invalid_config;
+    // Empty base_url
+    auto result = adapter.set_config(invalid_config);
+
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), adapter_error::invalid_configuration);
+}
+
+TEST_F(AdapterConfigUpdateTest, SetConfigValid) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter(config);
+
+    emr_adapter_config new_config = config;
+    new_config.base_url = "https://new-emr.example.com/fhir";
+
+    auto result = adapter.set_config(new_config);
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(adapter.config().base_url, "https://new-emr.example.com/fhir");
+}
+
+// =============================================================================
+// Move Semantics Tests
+// =============================================================================
+
+class AdapterMoveSemanticsTest : public ::testing::Test {
+protected:
+    emr_adapter_config create_valid_config() {
+        emr_adapter_config config;
+        config.vendor = emr_vendor::generic_fhir;
+        config.base_url = "https://emr.example.com/fhir";
+        config.auth_type = "oauth2";
+        config.client_id = "test_client";
+        config.token_url = "https://emr.example.com/oauth/token";
+        return config;
+    }
+};
+
+TEST_F(AdapterMoveSemanticsTest, MoveConstructor) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter1(config);
+
+    generic_fhir_adapter adapter2(std::move(adapter1));
+
+    EXPECT_EQ(adapter2.vendor(), emr_vendor::generic_fhir);
+    EXPECT_EQ(adapter2.config().base_url, "https://emr.example.com/fhir");
+}
+
+TEST_F(AdapterMoveSemanticsTest, MoveAssignment) {
+    auto config = create_valid_config();
+    generic_fhir_adapter adapter1(config);
+
+    emr_adapter_config config2 = config;
+    config2.base_url = "https://other.example.com/fhir";
+    generic_fhir_adapter adapter2(config2);
+
+    adapter2 = std::move(adapter1);
+
+    EXPECT_EQ(adapter2.config().base_url, "https://emr.example.com/fhir");
+}
+
+// =============================================================================
+// Vendor-Specific Configuration Tests
+// =============================================================================
+
+class VendorConfigTest : public ::testing::Test {};
+
+TEST_F(VendorConfigTest, EpicNonProductionFlag) {
+    emr_adapter_config config;
+    config.vendor = emr_vendor::epic;
+    config.base_url = "https://epic.example.com/fhir";
+    config.auth_type = "oauth2";
+    config.client_id = "epic_client";
+    config.token_url = "https://epic.example.com/oauth/token";
+    config.epic_non_production = true;
+
+    EXPECT_TRUE(config.is_valid());
+    EXPECT_TRUE(config.epic_non_production);
+}
+
+TEST_F(VendorConfigTest, CernerTenantId) {
+    emr_adapter_config config;
+    config.vendor = emr_vendor::cerner;
+    config.base_url = "https://cerner.example.com/fhir";
+    config.auth_type = "oauth2";
+    config.client_id = "cerner_client";
+    config.token_url = "https://cerner.example.com/oauth/token";
+    config.cerner_tenant_id = "tenant-12345";
+
+    EXPECT_TRUE(config.is_valid());
+    EXPECT_TRUE(config.cerner_tenant_id.has_value());
+    EXPECT_EQ(config.cerner_tenant_id.value(), "tenant-12345");
+}
+
+TEST_F(VendorConfigTest, MrnSystemConfiguration) {
+    emr_adapter_config config;
+    config.vendor = emr_vendor::generic_fhir;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "basic";
+    config.username = "admin";
+    config.mrn_system = "http://hospital.org/mrn";
+    config.organization_id = "org-12345";
+
+    EXPECT_TRUE(config.is_valid());
+    EXPECT_EQ(config.mrn_system.value(), "http://hospital.org/mrn");
+    EXPECT_EQ(config.organization_id.value(), "org-12345");
+}
+
+TEST_F(VendorConfigTest, ScopesConfiguration) {
+    emr_adapter_config config;
+    config.vendor = emr_vendor::generic_fhir;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "oauth2";
+    config.client_id = "client";
+    config.token_url = "https://emr.example.com/oauth/token";
+    config.scopes = {"patient/*.read", "user/*.read", "launch"};
+
+    EXPECT_TRUE(config.is_valid());
+    EXPECT_EQ(config.scopes.size(), 3);
+    EXPECT_EQ(config.scopes[0], "patient/*.read");
+}
+
+TEST_F(VendorConfigTest, RetryPolicyConfiguration) {
+    emr_adapter_config config;
+    config.vendor = emr_vendor::generic_fhir;
+    config.base_url = "https://emr.example.com/fhir";
+    config.auth_type = "basic";
+    config.username = "admin";
+    config.retry.max_retries = 5;
+    config.retry.initial_backoff = 500ms;
+    config.retry.backoff_multiplier = 2.0;
+    config.retry.max_backoff = 30000ms;
+
+    EXPECT_TRUE(config.is_valid());
+    EXPECT_EQ(config.retry.max_retries, 5);
+    EXPECT_EQ(config.retry.initial_backoff, 500ms);
+}


### PR DESCRIPTION
## Summary

- Implement vendor-agnostic EMR adapter interface for multi-vendor EMR integration support
- Add `emr_adapter.h` with abstract interface for EMR operations
- Add `generic_fhir_adapter` as default FHIR R4 implementation
- Add adapter factory for vendor-specific adapter creation
- Add comprehensive unit tests (47 tests) with 100% pass rate

## Features

### EMR Adapter Interface (`emr_adapter.h`)
- Abstract base class for vendor-specific adapters
- Patient lookup and search operations
- Result posting to EMR
- Encounter context retrieval
- Health check and connection management
- Statistics tracking

### Generic FHIR Adapter (`generic_fhir_adapter.h/cpp`)
- Default FHIR R4 compliant implementation
- Works with any EMR supporting FHIR R4 specification
- Integrates with existing `fhir_client`, `emr_patient_lookup`, and `emr_result_poster`

### Vendor Support
- Generic FHIR (default)
- Epic (via generic fallback, dedicated adapter planned for Phase 5.2+)
- Cerner/Oracle Health (via generic fallback)
- Meditech, Allscripts (stub for future implementation)

### Test Coverage (47 tests)
- Adapter error codes and messages
- EMR vendor parsing (generic, epic, cerner, meditech, allscripts)
- Configuration validation (OAuth2, Basic Auth)
- Adapter features verification
- Generic FHIR adapter interface compliance
- Factory function tests
- Move semantics tests
- Vendor-specific configuration tests

## Test plan

- [x] All 47 unit tests pass
- [x] Build succeeds with no errors
- [x] Test covers adapter error codes
- [x] Test covers vendor parsing
- [x] Test covers configuration validation
- [x] Test covers adapter factory
- [x] Test covers move semantics