### PR TITLE
fix(concepts): add missing string and string_view includes

### DIFF
--- a/include/pacs/bridge/concepts/bridge_concepts.h
+++ b/include/pacs/bridge/concepts/bridge_concepts.h
@@ -27,6 +27,8 @@
 #include <concepts>
 #include <functional>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <type_traits>
 
 namespace pacs::bridge::concepts {


### PR DESCRIPTION
## Summary

- Add missing `<string>` and `<string_view>` headers to `bridge_concepts.h`
- Fixes compilation errors when using `HL7Parseable` and `HL7Buildable` concepts

## Problem

The `HL7Parseable` concept uses `std::string_view` but the header was not included, causing build failures:

```
error: no type named 'string_view' in namespace 'std'
```

## Solution

Added missing includes:
```cpp
#include <string>
#include <string_view>
```

## Test Plan

- [x] Build passes (`ninja -j4` completes successfully)
- [x] All tests pass (`oauth2_test` - 37 passed, `emr_adapter_test` - 47 passed)