### PR TITLE
refactor(test): replace sleep_for with yield-based synchronization

### DIFF
--- a/tests/integration/emr_e2e_test.cpp
+++ b/tests/integration/emr_e2e_test.cpp
@@ -225,16 +225,19 @@ public:
     }
 
     /**
-     * @brief Wait for condition with timeout
+     * @brief Wait for condition with timeout using yield-based polling
+     *
+     * Uses std::this_thread::yield() instead of sleep_for for more
+     * responsive and deterministic test behavior.
      */
     static bool wait_for(std::function<bool()> condition,
                          std::chrono::milliseconds timeout) {
-        auto start = std::chrono::steady_clock::now();
+        auto deadline = std::chrono::steady_clock::now() + timeout;
         while (!condition()) {
-            if (std::chrono::steady_clock::now() - start > timeout) {
+            if (std::chrono::steady_clock::now() >= deadline) {
                 return false;
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds{10});
+            std::this_thread::yield();
         }
         return true;
     }

--- a/tests/integration/monitoring_integration_test.cpp
+++ b/tests/integration/monitoring_integration_test.cpp
@@ -615,10 +615,10 @@ bool test_system_metrics_periodic_update() {
     auto& metrics = bridge_metrics_collector::instance();
     metrics.set_enabled(true);
 
-    // Simulate periodic updates
+    // Simulate periodic updates with yield between calls
     for (int i = 0; i < 5; i++) {
         metrics.update_system_metrics();
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::yield();  // Allow other threads to run
     }
 
     // Should not crash and should have valid output


### PR DESCRIPTION
## Summary

- Replace `std::this_thread::sleep_for` with deterministic yield-based synchronization primitives in test files to eliminate test flakiness

## Changes

### New Utility in `test_helpers.h`
- Add `wait_for<Predicate>` template function for yield-based polling with configurable timeout

### Refactored Test Files
| File | Changes |
|------|---------|
| `prometheus_endpoint_test.cpp` | 12 sleep_for replaced with `wait_for_server_ready` helper |
| `config_manager_test.cpp` | File mtime polling instead of fixed sleep |
| `emr_e2e_test.cpp` | Internal `wait_for` now uses yield instead of sleep |
| `monitoring_integration_test.cpp` | Periodic update test uses yield |

### Preserved (Intentional Delays)
- Timing measurement tests in `bridge_metrics_test.cpp` (measuring actual elapsed time)
- Response delay simulation in `integration_test_base.h` (simulating network latency)

## Test Plan

- [x] All modified tests pass locally
- [x] `prometheus_endpoint_test`: 11/11 passed
- [x] `config_manager_test`: 21/21 passed
- [x] `monitoring_integration_test`: 16/16 passed
- [x] `emr_e2e_test`: 7/7 passed
- [x] `bridge_metrics_test`: 21/21 passed (unchanged)

## Notes

- Some pre-existing test failures in `queue_manager_test.cpp` are unrelated to this change
- The original issue #69 listed files that no longer contain `sleep_for` (already refactored)

Closes #69