### PR TITLE
refactor(fhir): complete std::expected pattern adoption

### DIFF
--- a/include/pacs/bridge/fhir/fhir_server.h
+++ b/include/pacs/bridge/fhir/fhir_server.h
@@ -23,6 +23,7 @@
 #include "fhir_types.h"
 #include "resource_handler.h"
 
+#include <expected>
 #include <functional>
 #include <memory>
 #include <string>
@@ -175,9 +176,9 @@ public:
      * Binds to the configured port and starts accepting connections.
      * Returns immediately; server runs in background threads.
      *
-     * @return true if started successfully, false on error
+     * @return Success or fhir_error
      */
-    [[nodiscard]] bool start();
+    [[nodiscard]] std::expected<void, fhir_error> start();
 
     /**
      * @brief Stop the FHIR server

--- a/include/pacs/bridge/fhir/fhir_types.h
+++ b/include/pacs/bridge/fhir/fhir_types.h
@@ -176,6 +176,32 @@ enum class fhir_error : int {
 }
 
 /**
+ * @brief Get human-readable description of FHIR error
+ */
+[[nodiscard]] constexpr const char* to_string(fhir_error error) noexcept {
+    switch (error) {
+        case fhir_error::invalid_resource:
+            return "Invalid FHIR resource";
+        case fhir_error::resource_not_found:
+            return "Resource not found";
+        case fhir_error::validation_failed:
+            return "Resource validation failed";
+        case fhir_error::unsupported_resource_type:
+            return "Unsupported resource type";
+        case fhir_error::server_error:
+            return "Server error";
+        case fhir_error::subscription_error:
+            return "Subscription error";
+        case fhir_error::json_parse_error:
+            return "JSON parsing error";
+        case fhir_error::missing_required_field:
+            return "Missing required field";
+        default:
+            return "Unknown FHIR error";
+    }
+}
+
+/**
  * @brief FHIR resource types supported by the gateway
  */
 enum class resource_type {

--- a/src/fhir/fhir_server.cpp
+++ b/src/fhir/fhir_server.cpp
@@ -282,11 +282,11 @@ public:
 
     ~impl() { stop(true); }
 
-    bool start() {
+    std::expected<void, fhir_error> start() {
         if (running_.exchange(true)) {
-            return false;  // Already running
+            return std::unexpected(fhir_error::server_error);  // Already running
         }
-        return true;
+        return {};
     }
 
     void stop(bool wait_for_requests) {
@@ -657,7 +657,7 @@ fhir_server::~fhir_server() = default;
 fhir_server::fhir_server(fhir_server&&) noexcept = default;
 fhir_server& fhir_server::operator=(fhir_server&&) noexcept = default;
 
-bool fhir_server::start() { return impl_->start(); }
+std::expected<void, fhir_error> fhir_server::start() { return impl_->start(); }
 
 void fhir_server::stop(bool wait_for_requests) {
     impl_->stop(wait_for_requests);


### PR DESCRIPTION
## Summary
- Apply `std::expected<void, fhir_error>` pattern to `fhir_server::start()`
- Add `to_string(fhir_error)` function for consistent error handling
- Complete std::expected pattern adoption across all pacs_bridge modules

## Background
Issue #141 requested applying the Result<T> pattern globally. Upon analysis, the codebase was already using C++23 `std::expected<T, E>` extensively. The only remaining gap was `fhir_server::start()` which returned `bool`.

## Changes
| File | Change |
|------|--------|
| `fhir_types.h` | Added `to_string(fhir_error)` function |
| `fhir_server.h` | Changed `start()` return type |
| `fhir_server.cpp` | Updated implementation |

## Error Code Ranges (All Modules)
- HL7 Core: -950 to -969
- ADT/ORM/SIU Handlers: -850 to -879
- Mapping: -940 to -949
- Router: -930 to -939
- MLLP: -970 to -979
- FHIR: -800 to -849

## Test Plan
- [x] Build with `BRIDGE_BUILD_FHIR=ON`
- [x] Run `fhir_server_test` - passed
- [x] Run FHIR related unit tests

Closes #141