### PR TITLE
[Phase 2] Integrate IExecutor for MPPS & MLLP Components

### DIFF
--- a/include/pacs/bridge/mllp/mllp_client.h
+++ b/include/pacs/bridge/mllp/mllp_client.h
@@ -298,6 +298,11 @@ struct mllp_pool_config {
 
     /** Health check interval */
     std::chrono::seconds health_check_interval{30};
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /** Optional executor for task execution (nullptr = use internal std::thread) */
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
+#endif
 };
 
 /**

--- a/include/pacs/bridge/mllp/mllp_types.h
+++ b/include/pacs/bridge/mllp/mllp_types.h
@@ -22,9 +22,15 @@
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
+
+// IExecutor interface for task execution (when available)
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+#include <kcenon/common/interfaces/executor_interface.h>
+#endif
 
 namespace pacs::bridge::mllp {
 
@@ -156,6 +162,11 @@ struct mllp_server_config {
 
     /** TLS configuration (disabled by default) */
     security::tls_config tls;
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /** Optional executor for task execution (nullptr = use internal std::thread) */
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
+#endif
 
     /** Validate configuration */
     [[nodiscard]] bool is_valid() const noexcept {

--- a/include/pacs/bridge/pacs_adapter/mpps_handler.h
+++ b/include/pacs/bridge/pacs_adapter/mpps_handler.h
@@ -33,6 +33,11 @@
 #include <string_view>
 #include <vector>
 
+// IExecutor interface for task execution (when available)
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+#include <kcenon/common/interfaces/executor_interface.h>
+#endif
+
 namespace pacs::bridge::pacs_adapter {
 
 // =============================================================================
@@ -412,6 +417,15 @@ struct mpps_handler_config {
 
     /** Maximum age for recovering pending MPPS (0 = no limit) */
     std::chrono::hours max_recovery_age{24};
+
+    // =========================================================================
+    // Executor Options (IExecutor integration)
+    // =========================================================================
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /** Optional executor for task execution (nullptr = use internal std::thread) */
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
+#endif
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

This PR integrates the `IExecutor` interface from `common_system` for task execution in MPPS and MLLP components, replacing direct `std::thread` usage with a more flexible executor-based model.

### Changes

- **mpps_handler**: Monitor thread replaced with scheduled executor jobs using `execute_delayed`
- **mllp_server**: Session handling via executor job submissions using `execute`
- **mllp_client**: Health check thread in connection pool replaced with scheduled executor jobs

### Implementation Details

- Added `IExecutor` config option to `mpps_handler_config`, `mllp_server_config`, and `mllp_pool_config`
- Created job classes: `mpps_monitor_job`, `mllp_session_job`, `mllp_health_check_job`
- Used `execute_delayed` for periodic tasks (monitoring, health checks)
- Used `execute` for immediate session handling tasks
- Maintained backward compatibility with `std::thread` fallback when executor is not provided
- Used conditional compilation (`PACS_BRIDGE_STANDALONE_BUILD`) for standalone build support

### Files Changed

- `include/pacs/bridge/pacs_adapter/mpps_handler.h`
- `include/pacs/bridge/mllp/mllp_types.h`
- `include/pacs/bridge/mllp/mllp_client.h`
- `src/pacs_adapter/mpps_handler.cpp`
- `src/mllp/mllp_server.cpp`
- `src/mllp/mllp_client.cpp`

## Test Plan

- [x] Build passes with standalone mode
- [ ] Build passes with integrated mode (requires common_system)
- [ ] Unit tests pass
- [ ] ThreadSanitizer validation

## Related Issues

- Resolves: #205
- Parent Epic: #198