### PR TITLE
feat(integration): add IExecutor interface adapter for bridge server (Phase 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,25 @@ if(BRIDGE_BUILD_HL7)
     )
 endif()
 
+# Integration Module - IExecutor adapter
+# See: https://github.com/kcenon/pacs_bridge/issues/198
+# Only available in non-standalone build (requires common_system)
+if(NOT BRIDGE_STANDALONE_BUILD)
+    list(APPEND PACS_BRIDGE_SOURCES
+        src/integration/executor_adapter.cpp
+    )
+    list(APPEND PACS_BRIDGE_HEADERS
+        include/pacs/bridge/integration/executor_adapter.h
+    )
+endif()
+
+# Other integration adapters (always available)
+list(APPEND PACS_BRIDGE_HEADERS
+    include/pacs/bridge/integration/logger_adapter.h
+    include/pacs/bridge/integration/network_adapter.h
+    include/pacs/bridge/integration/thread_adapter.h
+)
+
 # MLLP Transport
 list(APPEND PACS_BRIDGE_SOURCES
     src/mllp/mllp_server.cpp

--- a/include/pacs/bridge/bridge_server.h
+++ b/include/pacs/bridge/bridge_server.h
@@ -25,6 +25,10 @@
 #include "pacs/bridge/config/bridge_config.h"
 #include "pacs/bridge/monitoring/health_types.h"
 
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+#include <kcenon/common/interfaces/executor_interface.h>
+#endif
+
 #include <chrono>
 #include <expected>
 #include <filesystem>
@@ -318,6 +322,20 @@ public:
      */
     explicit bridge_server(const config::bridge_config& config);
 
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /**
+     * @brief Construct bridge server with configuration and executor
+     *
+     * @param config Bridge configuration
+     * @param executor IExecutor for task execution (optional, creates internal if null)
+     * @throws std::invalid_argument if config is invalid
+     * @see https://github.com/kcenon/pacs_bridge/issues/198
+     */
+    bridge_server(
+        const config::bridge_config& config,
+        std::shared_ptr<kcenon::common::interfaces::IExecutor> executor);
+#endif
+
     /**
      * @brief Construct bridge server from configuration file
      *
@@ -327,6 +345,20 @@ public:
      * @throws std::runtime_error if file cannot be loaded or parsed
      */
     explicit bridge_server(const std::filesystem::path& config_path);
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /**
+     * @brief Construct bridge server from configuration file with executor
+     *
+     * @param config_path Path to configuration file
+     * @param executor IExecutor for task execution (optional, creates internal if null)
+     * @throws std::runtime_error if file cannot be loaded or parsed
+     * @see https://github.com/kcenon/pacs_bridge/issues/198
+     */
+    bridge_server(
+        const std::filesystem::path& config_path,
+        std::shared_ptr<kcenon::common::interfaces::IExecutor> executor);
+#endif
 
     /**
      * @brief Destructor - stops server if running

--- a/include/pacs/bridge/integration/executor_adapter.h
+++ b/include/pacs/bridge/integration/executor_adapter.h
@@ -1,0 +1,386 @@
+#ifndef PACS_BRIDGE_INTEGRATION_EXECUTOR_ADAPTER_H
+#define PACS_BRIDGE_INTEGRATION_EXECUTOR_ADAPTER_H
+
+/**
+ * @file executor_adapter.h
+ * @brief Integration Module - IExecutor adapter for pacs_bridge
+ *
+ * Provides adapters that bridge common_system's IExecutor interface
+ * with pacs_bridge's thread infrastructure. Enables workflow modules
+ * to use the standardized IExecutor interface while leveraging existing
+ * thread pool implementations.
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/198
+ * @see common_system's executor_interface.h
+ * @see docs/SDS_COMPONENTS.md - Section 8: Integration Module
+ */
+
+#include <kcenon/common/interfaces/executor_interface.h>
+#include <kcenon/common/patterns/result.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace kcenon::thread {
+class thread_pool;
+}  // namespace kcenon::thread
+
+namespace pacs::bridge::integration {
+
+// =============================================================================
+// Lambda Job - Callable wrapper for IJob interface
+// =============================================================================
+
+/**
+ * @class lambda_job
+ * @brief IJob implementation that wraps a callable
+ *
+ * This class adapts a std::function to the IJob interface, allowing
+ * lambda expressions and other callables to be used with IExecutor.
+ *
+ * @example
+ * @code
+ * auto job = std::make_unique<lambda_job>(
+ *     []() -> kcenon::common::VoidResult {
+ *         // Do work...
+ *         return kcenon::common::VoidResult(std::monostate{});
+ *     },
+ *     "my_job",
+ *     5  // priority
+ * );
+ * executor->execute(std::move(job));
+ * @endcode
+ */
+class lambda_job : public kcenon::common::interfaces::IJob {
+public:
+    using job_function = std::function<kcenon::common::VoidResult()>;
+
+    /**
+     * @brief Construct a lambda job
+     *
+     * @param func The function to execute
+     * @param name Job name for logging (default: "lambda_job")
+     * @param priority Job priority (default: 0)
+     */
+    explicit lambda_job(
+        job_function func,
+        std::string name = "lambda_job",
+        int priority = 0)
+        : func_(std::move(func))
+        , name_(std::move(name))
+        , priority_(priority) {}
+
+    /**
+     * @brief Construct from void-returning callable
+     *
+     * @param func Void-returning function
+     * @param name Job name for logging
+     * @param priority Job priority
+     */
+    template <typename F>
+        requires std::is_void_v<std::invoke_result_t<F>>
+    explicit lambda_job(F&& func, std::string name = "lambda_job", int priority = 0)
+        : func_([f = std::forward<F>(func)]() -> kcenon::common::VoidResult {
+              f();
+              return kcenon::common::VoidResult(std::monostate{});
+          })
+        , name_(std::move(name))
+        , priority_(priority) {}
+
+    kcenon::common::VoidResult execute() override {
+        if (!func_) {
+            return kcenon::common::VoidResult(
+                kcenon::common::error_info{-1, "No function provided", "executor"});
+        }
+        return func_();
+    }
+
+    [[nodiscard]] std::string get_name() const override { return name_; }
+    [[nodiscard]] int get_priority() const override { return priority_; }
+
+private:
+    job_function func_;
+    std::string name_;
+    int priority_;
+};
+
+// =============================================================================
+// Thread Pool Executor Adapter
+// =============================================================================
+
+/**
+ * @class thread_pool_executor_adapter
+ * @brief IExecutor implementation using kcenon::thread::thread_pool
+ *
+ * This class adapts kcenon::thread::thread_pool to the IExecutor interface,
+ * enabling standardized task execution across the pacs_bridge workflow modules.
+ *
+ * Thread Safety: All public methods are thread-safe.
+ *
+ * @example
+ * @code
+ * // Create executor with thread pool
+ * auto pool = std::make_shared<kcenon::thread::thread_pool>(4);
+ * auto executor = std::make_shared<thread_pool_executor_adapter>(pool);
+ *
+ * // Submit job
+ * auto job = std::make_unique<lambda_job>([]() {
+ *     // Work...
+ *     return kcenon::common::VoidResult(std::monostate{});
+ * });
+ * auto result = executor->execute(std::move(job));
+ * if (result.is_ok()) {
+ *     result.value().wait();
+ * }
+ * @endcode
+ */
+class thread_pool_executor_adapter : public kcenon::common::interfaces::IExecutor {
+public:
+    /**
+     * @brief Construct adapter with thread pool
+     *
+     * @param pool Existing thread pool to use
+     */
+    explicit thread_pool_executor_adapter(
+        std::shared_ptr<kcenon::thread::thread_pool> pool);
+
+    /**
+     * @brief Construct adapter with worker count
+     *
+     * Creates a new thread pool with the specified number of workers.
+     *
+     * @param worker_count Number of worker threads
+     */
+    explicit thread_pool_executor_adapter(std::size_t worker_count);
+
+    /**
+     * @brief Destructor - ensures graceful shutdown
+     */
+    ~thread_pool_executor_adapter() override;
+
+    // Non-copyable, non-movable
+    thread_pool_executor_adapter(const thread_pool_executor_adapter&) = delete;
+    thread_pool_executor_adapter& operator=(const thread_pool_executor_adapter&) = delete;
+    thread_pool_executor_adapter(thread_pool_executor_adapter&&) = delete;
+    thread_pool_executor_adapter& operator=(thread_pool_executor_adapter&&) = delete;
+
+    // =========================================================================
+    // IExecutor Implementation
+    // =========================================================================
+
+    /**
+     * @brief Execute a job
+     *
+     * Submits the job to the thread pool for asynchronous execution.
+     *
+     * @param job The job to execute
+     * @return Result containing future or error
+     */
+    [[nodiscard]] kcenon::common::Result<std::future<void>> execute(
+        std::unique_ptr<kcenon::common::interfaces::IJob>&& job) override;
+
+    /**
+     * @brief Execute a job with delay
+     *
+     * @param job The job to execute
+     * @param delay The delay before execution
+     * @return Result containing future or error
+     */
+    [[nodiscard]] kcenon::common::Result<std::future<void>> execute_delayed(
+        std::unique_ptr<kcenon::common::interfaces::IJob>&& job,
+        std::chrono::milliseconds delay) override;
+
+    /**
+     * @brief Get the number of worker threads
+     */
+    [[nodiscard]] std::size_t worker_count() const override;
+
+    /**
+     * @brief Check if the executor is running
+     */
+    [[nodiscard]] bool is_running() const override;
+
+    /**
+     * @brief Get the number of pending tasks
+     */
+    [[nodiscard]] std::size_t pending_tasks() const override;
+
+    /**
+     * @brief Shutdown the executor
+     *
+     * @param wait_for_completion Wait for all pending tasks to complete
+     */
+    void shutdown(bool wait_for_completion = true) override;
+
+    // =========================================================================
+    // Convenience Methods
+    // =========================================================================
+
+    /**
+     * @brief Submit a void-returning callable directly
+     *
+     * This is a convenience method that wraps the callable in a lambda_job.
+     *
+     * @tparam F Callable type
+     * @param func The function to execute
+     * @param name Job name for logging
+     * @return Result containing future or error
+     */
+    template <typename F>
+        requires std::invocable<F>
+    [[nodiscard]] auto submit(F&& func, std::string name = "submitted_job")
+        -> kcenon::common::Result<std::future<void>> {
+        auto job = std::make_unique<lambda_job>(std::forward<F>(func), std::move(name));
+        return execute(std::move(job));
+    }
+
+    /**
+     * @brief Get the underlying thread pool
+     */
+    [[nodiscard]] auto get_underlying_pool() const
+        -> std::shared_ptr<kcenon::thread::thread_pool>;
+
+private:
+    void start_delay_thread();
+    void delay_thread_loop();
+
+    std::shared_ptr<kcenon::thread::thread_pool> pool_;
+    std::size_t worker_count_;
+    std::atomic<bool> running_{true};
+    std::atomic<std::size_t> pending_count_{0};
+
+    // For delayed execution
+    std::thread delay_thread_;
+    std::mutex delay_mutex_;
+    std::condition_variable delay_cv_;
+    std::atomic<bool> shutdown_requested_{false};
+
+    struct delayed_task {
+        std::chrono::steady_clock::time_point execute_at;
+        std::function<void()> task;
+
+        bool operator>(const delayed_task& other) const {
+            return execute_at > other.execute_at;
+        }
+    };
+    std::priority_queue<delayed_task, std::vector<delayed_task>,
+                        std::greater<delayed_task>> delayed_tasks_;
+};
+
+// =============================================================================
+// Simple Executor - Lightweight executor for simpler use cases
+// =============================================================================
+
+/**
+ * @class simple_executor
+ * @brief Lightweight IExecutor implementation with internal thread pool
+ *
+ * A self-contained executor that manages its own worker threads.
+ * Suitable for components that don't need to share a thread pool.
+ */
+class simple_executor : public kcenon::common::interfaces::IExecutor {
+public:
+    /**
+     * @brief Construct with specified worker count
+     *
+     * @param worker_count Number of worker threads (default: hardware concurrency)
+     */
+    explicit simple_executor(
+        std::size_t worker_count = std::thread::hardware_concurrency());
+
+    ~simple_executor() override;
+
+    // Non-copyable, non-movable
+    simple_executor(const simple_executor&) = delete;
+    simple_executor& operator=(const simple_executor&) = delete;
+    simple_executor(simple_executor&&) = delete;
+    simple_executor& operator=(simple_executor&&) = delete;
+
+    // IExecutor implementation
+    [[nodiscard]] kcenon::common::Result<std::future<void>> execute(
+        std::unique_ptr<kcenon::common::interfaces::IJob>&& job) override;
+
+    [[nodiscard]] kcenon::common::Result<std::future<void>> execute_delayed(
+        std::unique_ptr<kcenon::common::interfaces::IJob>&& job,
+        std::chrono::milliseconds delay) override;
+
+    [[nodiscard]] std::size_t worker_count() const override;
+    [[nodiscard]] bool is_running() const override;
+    [[nodiscard]] std::size_t pending_tasks() const override;
+    void shutdown(bool wait_for_completion = true) override;
+
+    /**
+     * @brief Submit a callable directly
+     */
+    template <typename F>
+        requires std::invocable<F>
+    [[nodiscard]] auto submit(F&& func, std::string name = "submitted_job")
+        -> kcenon::common::Result<std::future<void>> {
+        auto job = std::make_unique<lambda_job>(std::forward<F>(func), std::move(name));
+        return execute(std::move(job));
+    }
+
+private:
+    void worker_loop();
+    void delay_thread_loop();
+
+    std::size_t worker_count_;
+    std::vector<std::thread> workers_;
+    std::thread delay_thread_;
+
+    std::queue<std::function<void()>> task_queue_;
+    std::mutex queue_mutex_;
+    std::condition_variable queue_cv_;
+
+    std::priority_queue<delayed_task, std::vector<delayed_task>,
+                        std::greater<delayed_task>> delayed_tasks_;
+    std::mutex delay_mutex_;
+    std::condition_variable delay_cv_;
+
+    std::atomic<bool> running_{true};
+    std::atomic<std::size_t> pending_count_{0};
+
+    struct delayed_task {
+        std::chrono::steady_clock::time_point execute_at;
+        std::function<void()> task;
+
+        bool operator>(const delayed_task& other) const {
+            return execute_at > other.execute_at;
+        }
+    };
+};
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+/**
+ * @brief Create an executor with specified worker count
+ *
+ * @param worker_count Number of worker threads
+ * @return Shared pointer to IExecutor implementation
+ */
+[[nodiscard]] std::shared_ptr<kcenon::common::interfaces::IExecutor>
+make_executor(std::size_t worker_count = std::thread::hardware_concurrency());
+
+/**
+ * @brief Create an executor from existing thread pool
+ *
+ * @param pool The thread pool to wrap
+ * @return Shared pointer to IExecutor implementation
+ */
+[[nodiscard]] std::shared_ptr<kcenon::common::interfaces::IExecutor>
+make_executor(std::shared_ptr<kcenon::thread::thread_pool> pool);
+
+}  // namespace pacs::bridge::integration
+
+#endif  // PACS_BRIDGE_INTEGRATION_EXECUTOR_ADAPTER_H

--- a/src/integration/executor_adapter.cpp
+++ b/src/integration/executor_adapter.cpp
@@ -1,0 +1,420 @@
+/**
+ * @file executor_adapter.cpp
+ * @brief Implementation of IExecutor adapter for pacs_bridge
+ *
+ * @see include/pacs/bridge/integration/executor_adapter.h
+ * @see https://github.com/kcenon/pacs_bridge/issues/198
+ */
+
+#include "pacs/bridge/integration/executor_adapter.h"
+
+#include <kcenon/thread/thread_pool.h>
+
+#include <exception>
+
+namespace pacs::bridge::integration {
+
+// =============================================================================
+// thread_pool_executor_adapter Implementation
+// =============================================================================
+
+thread_pool_executor_adapter::thread_pool_executor_adapter(
+    std::shared_ptr<kcenon::thread::thread_pool> pool)
+    : pool_(std::move(pool))
+    , worker_count_(pool_ ? pool_->worker_count() : 0) {
+    start_delay_thread();
+}
+
+thread_pool_executor_adapter::thread_pool_executor_adapter(std::size_t worker_count)
+    : pool_(std::make_shared<kcenon::thread::thread_pool>(worker_count))
+    , worker_count_(worker_count) {
+    start_delay_thread();
+}
+
+thread_pool_executor_adapter::~thread_pool_executor_adapter() {
+    shutdown(true);
+}
+
+void thread_pool_executor_adapter::start_delay_thread() {
+    delay_thread_ = std::thread([this] { delay_thread_loop(); });
+}
+
+void thread_pool_executor_adapter::delay_thread_loop() {
+    while (!shutdown_requested_.load(std::memory_order_acquire)) {
+        std::unique_lock<std::mutex> lock(delay_mutex_);
+
+        if (delayed_tasks_.empty()) {
+            delay_cv_.wait(lock, [this] {
+                return shutdown_requested_.load(std::memory_order_acquire) ||
+                       !delayed_tasks_.empty();
+            });
+        }
+
+        if (shutdown_requested_.load(std::memory_order_acquire)) {
+            break;
+        }
+
+        while (!delayed_tasks_.empty()) {
+            auto& top = delayed_tasks_.top();
+            auto now = std::chrono::steady_clock::now();
+
+            if (top.execute_at <= now) {
+                auto task = std::move(const_cast<delayed_task&>(top).task);
+                delayed_tasks_.pop();
+                lock.unlock();
+
+                if (task) {
+                    task();
+                }
+
+                lock.lock();
+            } else {
+                delay_cv_.wait_until(lock, top.execute_at, [this] {
+                    return shutdown_requested_.load(std::memory_order_acquire);
+                });
+
+                if (shutdown_requested_.load(std::memory_order_acquire)) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+kcenon::common::Result<std::future<void>> thread_pool_executor_adapter::execute(
+    std::unique_ptr<kcenon::common::interfaces::IJob>&& job) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-1, "Executor is not running", "executor"});
+    }
+
+    if (!job) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-2, "Job is null", "executor"});
+    }
+
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+    auto shared_job = std::shared_ptr<kcenon::common::interfaces::IJob>(std::move(job));
+
+    pending_count_.fetch_add(1, std::memory_order_release);
+
+    pool_->submit_task([this, shared_job, promise]() {
+        try {
+            auto result = shared_job->execute();
+            if (result.is_ok()) {
+                promise->set_value();
+            } else {
+                promise->set_exception(std::make_exception_ptr(
+                    std::runtime_error(result.error().message)));
+            }
+        } catch (...) {
+            promise->set_exception(std::current_exception());
+        }
+        pending_count_.fetch_sub(1, std::memory_order_release);
+    });
+
+    return kcenon::common::Result<std::future<void>>(std::move(future));
+}
+
+kcenon::common::Result<std::future<void>> thread_pool_executor_adapter::execute_delayed(
+    std::unique_ptr<kcenon::common::interfaces::IJob>&& job,
+    std::chrono::milliseconds delay) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-1, "Executor is not running", "executor"});
+    }
+
+    if (!job) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-2, "Job is null", "executor"});
+    }
+
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+    auto shared_job = std::shared_ptr<kcenon::common::interfaces::IJob>(std::move(job));
+
+    pending_count_.fetch_add(1, std::memory_order_release);
+
+    {
+        std::lock_guard<std::mutex> lock(delay_mutex_);
+        delayed_tasks_.push(delayed_task{
+            std::chrono::steady_clock::now() + delay,
+            [this, shared_job, promise]() {
+                pool_->submit_task([this, shared_job, promise]() {
+                    try {
+                        auto result = shared_job->execute();
+                        if (result.is_ok()) {
+                            promise->set_value();
+                        } else {
+                            promise->set_exception(std::make_exception_ptr(
+                                std::runtime_error(result.error().message)));
+                        }
+                    } catch (...) {
+                        promise->set_exception(std::current_exception());
+                    }
+                    pending_count_.fetch_sub(1, std::memory_order_release);
+                });
+            }});
+    }
+    delay_cv_.notify_one();
+
+    return kcenon::common::Result<std::future<void>>(std::move(future));
+}
+
+std::size_t thread_pool_executor_adapter::worker_count() const {
+    return worker_count_;
+}
+
+bool thread_pool_executor_adapter::is_running() const {
+    return running_.load(std::memory_order_acquire);
+}
+
+std::size_t thread_pool_executor_adapter::pending_tasks() const {
+    return pending_count_.load(std::memory_order_acquire);
+}
+
+void thread_pool_executor_adapter::shutdown(bool wait_for_completion) {
+    if (!running_.exchange(false, std::memory_order_acq_rel)) {
+        return;  // Already shutdown
+    }
+
+    shutdown_requested_.store(true, std::memory_order_release);
+    delay_cv_.notify_all();
+
+    if (delay_thread_.joinable()) {
+        delay_thread_.join();
+    }
+
+    if (pool_ && wait_for_completion) {
+        pool_->stop(true);
+    }
+}
+
+std::shared_ptr<kcenon::thread::thread_pool>
+thread_pool_executor_adapter::get_underlying_pool() const {
+    return pool_;
+}
+
+// =============================================================================
+// simple_executor Implementation
+// =============================================================================
+
+simple_executor::simple_executor(std::size_t worker_count)
+    : worker_count_(worker_count > 0 ? worker_count : 1) {
+    for (std::size_t i = 0; i < worker_count_; ++i) {
+        workers_.emplace_back([this] { worker_loop(); });
+    }
+    delay_thread_ = std::thread([this] { delay_thread_loop(); });
+}
+
+simple_executor::~simple_executor() {
+    shutdown(true);
+}
+
+void simple_executor::worker_loop() {
+    while (true) {
+        std::function<void()> task;
+
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            queue_cv_.wait(lock, [this] {
+                return !running_.load(std::memory_order_acquire) || !task_queue_.empty();
+            });
+
+            if (!running_.load(std::memory_order_acquire) && task_queue_.empty()) {
+                return;
+            }
+
+            if (!task_queue_.empty()) {
+                task = std::move(task_queue_.front());
+                task_queue_.pop();
+            }
+        }
+
+        if (task) {
+            task();
+        }
+    }
+}
+
+void simple_executor::delay_thread_loop() {
+    while (running_.load(std::memory_order_acquire)) {
+        std::unique_lock<std::mutex> lock(delay_mutex_);
+
+        if (delayed_tasks_.empty()) {
+            delay_cv_.wait(lock, [this] {
+                return !running_.load(std::memory_order_acquire) ||
+                       !delayed_tasks_.empty();
+            });
+        }
+
+        if (!running_.load(std::memory_order_acquire)) {
+            break;
+        }
+
+        while (!delayed_tasks_.empty()) {
+            auto& top = delayed_tasks_.top();
+            auto now = std::chrono::steady_clock::now();
+
+            if (top.execute_at <= now) {
+                auto task = std::move(const_cast<delayed_task&>(top).task);
+                delayed_tasks_.pop();
+                lock.unlock();
+
+                if (task) {
+                    std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+                    task_queue_.push(std::move(task));
+                    queue_cv_.notify_one();
+                }
+
+                lock.lock();
+            } else {
+                delay_cv_.wait_until(lock, top.execute_at, [this] {
+                    return !running_.load(std::memory_order_acquire);
+                });
+
+                if (!running_.load(std::memory_order_acquire)) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+kcenon::common::Result<std::future<void>> simple_executor::execute(
+    std::unique_ptr<kcenon::common::interfaces::IJob>&& job) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-1, "Executor is not running", "executor"});
+    }
+
+    if (!job) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-2, "Job is null", "executor"});
+    }
+
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+    auto shared_job = std::shared_ptr<kcenon::common::interfaces::IJob>(std::move(job));
+
+    pending_count_.fetch_add(1, std::memory_order_release);
+
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        task_queue_.push([this, shared_job, promise]() {
+            try {
+                auto result = shared_job->execute();
+                if (result.is_ok()) {
+                    promise->set_value();
+                } else {
+                    promise->set_exception(std::make_exception_ptr(
+                        std::runtime_error(result.error().message)));
+                }
+            } catch (...) {
+                promise->set_exception(std::current_exception());
+            }
+            pending_count_.fetch_sub(1, std::memory_order_release);
+        });
+    }
+    queue_cv_.notify_one();
+
+    return kcenon::common::Result<std::future<void>>(std::move(future));
+}
+
+kcenon::common::Result<std::future<void>> simple_executor::execute_delayed(
+    std::unique_ptr<kcenon::common::interfaces::IJob>&& job,
+    std::chrono::milliseconds delay) {
+    if (!running_.load(std::memory_order_acquire)) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-1, "Executor is not running", "executor"});
+    }
+
+    if (!job) {
+        return kcenon::common::Result<std::future<void>>(
+            kcenon::common::error_info{-2, "Job is null", "executor"});
+    }
+
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+    auto shared_job = std::shared_ptr<kcenon::common::interfaces::IJob>(std::move(job));
+
+    pending_count_.fetch_add(1, std::memory_order_release);
+
+    {
+        std::lock_guard<std::mutex> lock(delay_mutex_);
+        delayed_tasks_.push(delayed_task{
+            std::chrono::steady_clock::now() + delay,
+            [this, shared_job, promise]() {
+                try {
+                    auto result = shared_job->execute();
+                    if (result.is_ok()) {
+                        promise->set_value();
+                    } else {
+                        promise->set_exception(std::make_exception_ptr(
+                            std::runtime_error(result.error().message)));
+                    }
+                } catch (...) {
+                    promise->set_exception(std::current_exception());
+                }
+                pending_count_.fetch_sub(1, std::memory_order_release);
+            }});
+    }
+    delay_cv_.notify_one();
+
+    return kcenon::common::Result<std::future<void>>(std::move(future));
+}
+
+std::size_t simple_executor::worker_count() const {
+    return worker_count_;
+}
+
+bool simple_executor::is_running() const {
+    return running_.load(std::memory_order_acquire);
+}
+
+std::size_t simple_executor::pending_tasks() const {
+    return pending_count_.load(std::memory_order_acquire);
+}
+
+void simple_executor::shutdown(bool wait_for_completion) {
+    running_.store(false, std::memory_order_release);
+
+    queue_cv_.notify_all();
+    delay_cv_.notify_all();
+
+    if (delay_thread_.joinable()) {
+        delay_thread_.join();
+    }
+
+    for (auto& worker : workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+    workers_.clear();
+
+    // Clear remaining tasks if not waiting for completion
+    if (!wait_for_completion) {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        while (!task_queue_.empty()) {
+            task_queue_.pop();
+        }
+    }
+}
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+std::shared_ptr<kcenon::common::interfaces::IExecutor>
+make_executor(std::size_t worker_count) {
+    return std::make_shared<simple_executor>(worker_count);
+}
+
+std::shared_ptr<kcenon::common::interfaces::IExecutor>
+make_executor(std::shared_ptr<kcenon::thread::thread_pool> pool) {
+    return std::make_shared<thread_pool_executor_adapter>(std::move(pool));
+}
+
+}  // namespace pacs::bridge::integration


### PR DESCRIPTION
## Summary
- Add executor adapter infrastructure to integrate common_system's IExecutor interface into pacs_bridge
- Implement Phase 1 of #198: Bridge Server Core - Integrate IExecutor

## Changes
- **include/pacs/bridge/integration/executor_adapter.h**: New header with:
  - `lambda_job`: IJob implementation wrapping callables
  - `thread_pool_executor_adapter`: IExecutor using kcenon::thread::thread_pool
  - `simple_executor`: Lightweight self-contained executor
  - Factory functions for executor creation

- **src/integration/executor_adapter.cpp**: Full implementation of all executor classes

- **include/pacs/bridge/bridge_server.h**: 
  - Add IExecutor include (conditional for non-standalone build)
  - Add constructors accepting IExecutor parameter

- **src/bridge_server.cpp**:
  - Add executor initialization and lifecycle management
  - Support for external or internal executor

- **CMakeLists.txt**: 
  - Add integration module sources (conditional for non-standalone build)

## Technical Details
The executor adapter provides:
- Job-based execution with Result<T> error handling
- Delayed execution support via priority queue
- Configurable worker count
- Graceful shutdown with pending task completion
- Thread-safe implementation

## Conditional Compilation
- In standalone build mode (`PACS_BRIDGE_STANDALONE_BUILD`), executor adapter is disabled
- In full build mode, requires common_system's IExecutor interface

## Test Plan
- [x] Build passes in standalone mode
- [x] Existing tests pass
- [ ] Full build with dependencies (requires ecosystem setup)
- [ ] Unit tests for executor adapter (follow-up)

## Related Issues
- Resolves Phase 1 of #198
- Related sub-issues: #210 (Phase 1), #211 (Phase 2)
- Subsequent phases: #206, #207, #208