### PR TITLE
[Phase 3] Integrate IExecutor for Workflow & Router Components

### DIFF
--- a/docs/SDS_COMPONENTS.md
+++ b/docs/SDS_COMPONENTS.md
@@ -2385,6 +2385,10 @@ struct queue_config {
     double retry_backoff_multiplier = 2.0;
     std::chrono::seconds max_retry_delay{300};
     std::chrono::hours message_ttl{24};
+
+    // Optional IExecutor for worker/cleanup task execution
+    // When nullptr, uses internal std::thread (standalone mode)
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
 };
 
 /**

--- a/docs/SDS_COMPONENTS_KO.md
+++ b/docs/SDS_COMPONENTS_KO.md
@@ -1639,6 +1639,10 @@ struct queue_config {
     double retry_backoff_multiplier = 2.0;
     std::chrono::seconds max_retry_delay{300};
     std::chrono::hours message_ttl{24};
+
+    // 선택적 IExecutor - worker/cleanup 태스크 실행용
+    // nullptr일 경우 내부 std::thread 사용 (standalone 모드)
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
 };
 
 /**

--- a/include/pacs/bridge/router/queue_manager.h
+++ b/include/pacs/bridge/router/queue_manager.h
@@ -28,6 +28,11 @@
 #include <string_view>
 #include <vector>
 
+// IExecutor interface for task execution (when available)
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+#include <kcenon/common/interfaces/executor_interface.h>
+#endif
+
 namespace pacs::bridge::router {
 
 // =============================================================================
@@ -188,6 +193,11 @@ struct queue_config {
 
     /** Enable WAL mode for better concurrent access */
     bool enable_wal_mode = true;
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /** Optional executor for worker and cleanup task execution (nullptr = use internal std::thread) */
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
+#endif
 
     /**
      * @brief Validate configuration

--- a/include/pacs/bridge/workflow/mpps_hl7_workflow.h
+++ b/include/pacs/bridge/workflow/mpps_hl7_workflow.h
@@ -27,6 +27,11 @@
 #include "pacs/bridge/router/outbound_router.h"
 #include "pacs/bridge/router/queue_manager.h"
 
+// IExecutor interface for task execution (when available)
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+#include <kcenon/common/interfaces/executor_interface.h>
+#endif
+
 #include <chrono>
 #include <expected>
 #include <functional>
@@ -311,6 +316,11 @@ struct mpps_hl7_workflow_config {
 
     /** DICOM to HL7 mapper configuration */
     mapping::dicom_hl7_mapper_config mapper_config;
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /** Optional executor for async worker task execution (nullptr = use internal std::thread) */
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
+#endif
 
     /**
      * @brief Validate configuration


### PR DESCRIPTION
## Summary

- Refactored `mpps_hl7_workflow.cpp` to use IExecutor for async worker threads
- Refactored `queue_manager.cpp` to use IExecutor for worker and cleanup threads  
- Added `executor` field to both `mpps_hl7_workflow_config` and `queue_config`
- Uses `PACS_BRIDGE_STANDALONE_BUILD` macro for conditional compilation
- Falls back to `std::thread` when executor is not provided (standalone mode)

## Changes

### Header Files
- `include/pacs/bridge/workflow/mpps_hl7_workflow.h`: Added IExecutor include and executor config field
- `include/pacs/bridge/router/queue_manager.h`: Added IExecutor include and executor config field

### Implementation Files
- `src/workflow/mpps_hl7_workflow.cpp`:
  - Added `mpps_workflow_worker_job` class for IExecutor-based execution
  - Modified `start()` and `stop()` to support both IExecutor and std::thread modes
  - Added `schedule_worker_job()` method for continuous worker scheduling
  
- `src/router/queue_manager.cpp`:
  - Added `queue_worker_job` and `queue_cleanup_job` classes
  - Modified `start()`, `stop()`, `stop_workers()`, and `start_workers_internal()`
  - Added `schedule_worker_job()` and `schedule_cleanup_job()` methods

### Documentation
- Updated `docs/SDS_COMPONENTS.md` and `docs/SDS_COMPONENTS_KO.md` with executor field

## Test Plan

- [x] Build succeeds with no errors
- [x] 30/30 Workflow and QueueManager unit tests pass
- [x] Existing queue tests pass (1 pre-existing failure unrelated to this change)
- [ ] Integration testing with bridge_server executor injection

Closes #206