### PR TITLE
feat(bridge): pass IExecutor to queue and workflow components

### DIFF
--- a/src/bridge_server.cpp
+++ b/src/bridge_server.cpp
@@ -406,6 +406,11 @@ private:
         sender_config.queue.message_ttl = config_.queue.message_ttl;
         sender_config.queue.worker_count = config_.queue.worker_count;
 
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+        // Pass executor to queue for worker task execution (Issue #198)
+        sender_config.queue.executor = executor_;
+#endif
+
         // Configure destinations
         for (const auto& dest : config_.hl7.outbound_destinations) {
             router::outbound_destination router_dest;
@@ -429,6 +434,11 @@ private:
         wf_config.enable_queue_fallback = true;
         wf_config.enable_tracing = true;
         wf_config.enable_metrics = true;
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+        // Pass executor to workflow for async task execution (Issue #198)
+        wf_config.executor = executor_;
+#endif
 
         // Configure routing rules
         for (const auto& rule : config_.routing_rules) {


### PR DESCRIPTION
## Summary

- Pass IExecutor instance from bridge_server to child components
- Enable centralized executor management for worker tasks
- Improve resource management and testability

## Changes

- `src/bridge_server.cpp`:
  - Pass `executor_` to `reliable_sender_config.queue.executor` for queue worker tasks
  - Pass `executor_` to `mpps_hl7_workflow_config.executor` for async workflow processing

## Related Issues

- Resolves #225 Phase 1: Pass IExecutor to bridge server components
- Part of #198 [Refactor] Integrate IExecutor interface for bridge server workflow

## Sub-Issues Created

As part of this work, the following sub-issues were created for #198:
- #225 Phase 1: Pass IExecutor to bridge server components (this PR)
- #226 Phase 2: Migrate Router and Queue Manager to IExecutor
- #227 Phase 3: Migrate MLLP Components to IExecutor
- #228 Phase 4: Migrate Workflow and Messaging to IExecutor
- #229 Phase 5: Testing and Validation for IExecutor Migration

## Test Plan

- [x] Build succeeds
- [x] Existing tests pass (94% pass rate, failures are pre-existing)
- [ ] Manual verification of executor-based task execution

## Technical Notes

The executor is passed via conditional compilation (`#ifndef PACS_BRIDGE_STANDALONE_BUILD`) to maintain backward compatibility with standalone builds.