### PR TITLE
refactor(mllp): migrate MLLP components to IExecutor interface

### DIFF
--- a/include/pacs/bridge/mllp/mllp_types.h
+++ b/include/pacs/bridge/mllp/mllp_types.h
@@ -213,6 +213,11 @@ struct mllp_client_config {
     /** Keep connection alive for reuse */
     bool keep_alive = true;
 
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    /** Optional executor for async operations (nullptr = use std::async) */
+    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
+#endif
+
     /** Validate configuration */
     [[nodiscard]] bool is_valid() const noexcept {
         if (host.empty()) return false;


### PR DESCRIPTION
## Summary

- Migrate MLLP server accept loop to use IExecutor instead of direct std::thread
- Add executor support to mllp_client for async operations
- Maintain fallback to std::thread/std::async for standalone build

## Changes

### mllp_server.cpp
- Add `mllp_accept_job` class for executor-based accept loop execution
- Replace direct `std::thread` for accept loop with IExecutor job when executor is available
- Add `accept_future_` member to track executor-based accept loop
- Update shutdown logic to wait for accept future

### mllp_client.cpp
- Add `mllp_send_job` class for executor-based async send operations
- Update `send_async()` to use IExecutor when available
- Maintain fallback to `std::async` for standalone build

### mllp_types.h
- Add `executor` field to `mllp_client_config` for async operations

## Test Plan

- [x] All MLLP unit tests pass (23/23)
- [x] All MLLP connection integration tests pass (11/11)
- [x] Build succeeds with no new warnings
- [x] Fallback behavior preserved for standalone build

## Related Issues

Part of: #198 [Refactor] Integrate IExecutor interface for bridge server workflow
Closes: #227 [Refactor] Phase 3: Migrate MLLP Components to IExecutor