### PR TITLE
refactor(emr): migrate result_tracker to Result<T> pattern

### DIFF
--- a/tests/integration/emr_e2e_test.cpp
+++ b/tests/integration/emr_e2e_test.cpp
@@ -454,7 +454,7 @@ bool test_result_posting_workflow() {
     posted.posted_at = std::chrono::system_clock::now();
 
     auto track_result = tracker.track(posted);
-    E2E_TEST_ASSERT(track_result, "Should track result successfully");
+    E2E_TEST_ASSERT(track_result.is_ok(), "Should track result successfully");
 
     // Verify tracking
     auto tracked = tracker.get_by_study_uid(study_result.study_instance_uid);

--- a/tests/result_poster_test.cpp
+++ b/tests/result_poster_test.cpp
@@ -375,7 +375,7 @@ TEST_F(ResultTrackerTest, TrackNewResult) {
     result.status = result_status::final_report;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->track(result));
+    EXPECT_TRUE(tracker_->track(result).is_ok());
     EXPECT_EQ(tracker_->size(), 1);
     EXPECT_TRUE(tracker_->exists("1.2.3.4.5.6.7.8.9"));
 }
@@ -388,7 +388,7 @@ TEST_F(ResultTrackerTest, GetByStudyUid) {
     result.status = result_status::final_report;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->track(result));
+    EXPECT_TRUE(tracker_->track(result).is_ok());
 
     auto retrieved = tracker_->get_by_study_uid("1.2.3.4.5.6.7.8.9");
     ASSERT_TRUE(retrieved.has_value());
@@ -405,7 +405,7 @@ TEST_F(ResultTrackerTest, GetByAccessionNumber) {
     result.status = result_status::final_report;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->track(result));
+    EXPECT_TRUE(tracker_->track(result).is_ok());
 
     auto retrieved = tracker_->get_by_accession("ACC12345");
     ASSERT_TRUE(retrieved.has_value());
@@ -420,7 +420,7 @@ TEST_F(ResultTrackerTest, GetByReportId) {
     result.status = result_status::final_report;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->track(result));
+    EXPECT_TRUE(tracker_->track(result).is_ok());
 
     auto retrieved = tracker_->get_by_report_id("report-123");
     ASSERT_TRUE(retrieved.has_value());
@@ -441,13 +441,13 @@ TEST_F(ResultTrackerTest, UpdateExisting) {
     result.status = result_status::preliminary;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->track(result));
+    EXPECT_TRUE(tracker_->track(result).is_ok());
 
     // Update status
     result.status = result_status::final_report;
     result.updated_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->update("1.2.3.4.5.6.7.8.9", result));
+    EXPECT_TRUE(tracker_->update("1.2.3.4.5.6.7.8.9", result).is_ok());
 
     auto retrieved = tracker_->get_by_study_uid("1.2.3.4.5.6.7.8.9");
     ASSERT_TRUE(retrieved.has_value());
@@ -461,7 +461,7 @@ TEST_F(ResultTrackerTest, UpdateNonExistent) {
     result.status = result_status::final_report;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_FALSE(tracker_->update("nonexistent", result));
+    EXPECT_FALSE(tracker_->update("nonexistent", result).is_ok());
 }
 
 TEST_F(ResultTrackerTest, Remove) {
@@ -472,10 +472,10 @@ TEST_F(ResultTrackerTest, Remove) {
     result.status = result_status::final_report;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->track(result));
+    EXPECT_TRUE(tracker_->track(result).is_ok());
     EXPECT_EQ(tracker_->size(), 1);
 
-    EXPECT_TRUE(tracker_->remove("1.2.3.4.5.6.7.8.9"));
+    EXPECT_TRUE(tracker_->remove("1.2.3.4.5.6.7.8.9").is_ok());
     EXPECT_EQ(tracker_->size(), 0);
     EXPECT_FALSE(tracker_->exists("1.2.3.4.5.6.7.8.9"));
 
@@ -491,7 +491,7 @@ TEST_F(ResultTrackerTest, Clear) {
         result.study_instance_uid = "1.2.3.4.5.6.7.8." + std::to_string(i);
         result.status = result_status::final_report;
         result.posted_at = std::chrono::system_clock::now();
-        EXPECT_TRUE(tracker_->track(result));
+        EXPECT_TRUE(tracker_->track(result).is_ok());
     }
 
     EXPECT_EQ(tracker_->size(), 10);
@@ -507,7 +507,7 @@ TEST_F(ResultTrackerTest, Keys) {
         result.study_instance_uid = "1.2.3.4.5.6.7.8." + std::to_string(i);
         result.status = result_status::final_report;
         result.posted_at = std::chrono::system_clock::now();
-        EXPECT_TRUE(tracker_->track(result));
+        EXPECT_TRUE(tracker_->track(result).is_ok());
     }
 
     auto keys = tracker_->keys();
@@ -527,7 +527,7 @@ TEST_F(ResultTrackerTest, MaxEntriesEviction) {
         result.study_instance_uid = "1.2.3.4.5.6.7.8." + std::to_string(i);
         result.status = result_status::final_report;
         result.posted_at = std::chrono::system_clock::now();
-        EXPECT_TRUE(tracker_->track(result));
+        EXPECT_TRUE(tracker_->track(result).is_ok());
     }
 
     // Should have max_entries entries due to eviction
@@ -550,7 +550,7 @@ TEST_F(ResultTrackerTest, Statistics) {
     result.status = result_status::final_report;
     result.posted_at = std::chrono::system_clock::now();
 
-    EXPECT_TRUE(tracker_->track(result));
+    EXPECT_TRUE(tracker_->track(result).is_ok());
 
     stats = tracker_->get_statistics();
     EXPECT_EQ(stats.total_tracked, 1);


### PR DESCRIPTION
## Summary

- Migrate `result_tracker` interface to use `Result<T>` pattern
- Add `tracker_error` enum for result tracker specific error codes (-1020 to -1029)
- Change `track()`, `update()`, `remove()` methods to return `VoidResult`
- Update tests to use `.is_ok()` for Result validation

## Changes

### Header (`result_tracker.h`)
- Added `tracker_error` enum with error codes for:
  - `not_found` (-1020)
  - `capacity_exceeded` (-1021)
  - `invalid_entry` (-1022)
  - `already_exists` (-1023)
  - `operation_failed` (-1024)
- Added `to_error_code()`, `to_string()`, `to_error_info()` helper functions
- Changed interface methods to return `VoidResult`

### Implementation (`result_tracker.cpp`)
- Updated `impl` class methods to return `VoidResult`
- Return error_info with tracker_error codes on failure
- Return success with `VoidResult{std::monostate{}}`

### Tests
- Updated `result_poster_test.cpp` to use `.is_ok()` for Result checking
- Updated `emr_e2e_test.cpp` E2E_TEST_ASSERT to use `.is_ok()`

## Test Plan

- [x] All 13 ResultTracker tests pass
- [x] Build completes without errors
- [ ] Full test suite validation

## Related Issues

Closes #236

Part of #199 [Refactor] Adopt Result<T> pattern for EMR integration layer