### PR TITLE
refactor(fhir): adopt Result<T> pattern for FHIR server

### DIFF
--- a/include/pacs/bridge/fhir/fhir_server.h
+++ b/include/pacs/bridge/fhir/fhir_server.h
@@ -23,7 +23,6 @@
 #include "fhir_types.h"
 #include "resource_handler.h"
 
-#include <expected>
 #include <functional>
 #include <memory>
 #include <string>
@@ -176,9 +175,9 @@ public:
      * Binds to the configured port and starts accepting connections.
      * Returns immediately; server runs in background threads.
      *
-     * @return Success or fhir_error
+     * @return VoidResult indicating success or error
      */
-    [[nodiscard]] std::expected<void, fhir_error> start();
+    [[nodiscard]] VoidResult start();
 
     /**
      * @brief Stop the FHIR server

--- a/include/pacs/bridge/fhir/fhir_types.h
+++ b/include/pacs/bridge/fhir/fhir_types.h
@@ -19,7 +19,34 @@
 #include <string_view>
 #include <vector>
 
+// Result<T> pattern - use stub for standalone builds
+#ifdef PACS_BRIDGE_STANDALONE_BUILD
+#include <pacs/bridge/internal/result_stub.h>
+#else
+#include <kcenon/common/patterns/result.h>
+#endif
+
 namespace pacs::bridge::fhir {
+
+// =============================================================================
+// Result Type Aliases
+// =============================================================================
+
+/**
+ * @brief Result type alias for FHIR operations
+ */
+template<typename T>
+using Result = kcenon::common::Result<T>;
+
+/**
+ * @brief VoidResult type alias for operations with no return value
+ */
+using VoidResult = kcenon::common::VoidResult;
+
+/**
+ * @brief Error info type alias
+ */
+using error_info = kcenon::common::error_info;
 
 // =============================================================================
 // HTTP Types

--- a/src/fhir/fhir_server.cpp
+++ b/src/fhir/fhir_server.cpp
@@ -282,11 +282,13 @@ public:
 
     ~impl() { stop(true); }
 
-    std::expected<void, fhir_error> start() {
+    VoidResult start() {
         if (running_.exchange(true)) {
-            return std::unexpected(fhir_error::server_error);  // Already running
+            return VoidResult::err(error_info{
+                static_cast<int>(fhir_error::server_error),
+                "Server already running"});
         }
-        return {};
+        return VoidResult::ok();
     }
 
     void stop(bool wait_for_requests) {
@@ -657,7 +659,7 @@ fhir_server::~fhir_server() = default;
 fhir_server::fhir_server(fhir_server&&) noexcept = default;
 fhir_server& fhir_server::operator=(fhir_server&&) noexcept = default;
 
-std::expected<void, fhir_error> fhir_server::start() { return impl_->start(); }
+VoidResult fhir_server::start() { return impl_->start(); }
 
 void fhir_server::stop(bool wait_for_requests) {
     impl_->stop(wait_for_requests);


### PR DESCRIPTION
## Summary

- Add Result type aliases to fhir_types.h for FHIR module
- Replace std::expected<void, fhir_error> with VoidResult in fhir_server
- Update start() method implementation to use Result pattern

## Changes

- `include/pacs/bridge/fhir/fhir_types.h`: Add Result, VoidResult, and error_info type aliases
- `include/pacs/bridge/fhir/fhir_server.h`: Replace std::expected with VoidResult
- `src/fhir/fhir_server.cpp`: Update start() implementation

## Test plan

- [x] All FhirClientTest tests pass
- [x] All FhirBundleTest tests pass
- [x] Full build completes successfully

Closes #219