### PR TITLE
refactor(fhir): update FHIR resources for Result<T> pattern

### DIFF
--- a/src/fhir/imaging_study_resource.cpp
+++ b/src/fhir/imaging_study_resource.cpp
@@ -918,8 +918,8 @@ resource_result<std::unique_ptr<fhir_resource>> imaging_study_handler::read(
     // Convert DICOM study to FHIR ImagingStudy
     if (pimpl_->mapper_) {
         auto fhir_result = pimpl_->mapper_->study_to_imaging_study(*result);
-        if (fhir_result) {
-            return imaging_study_resource::from_mapping_struct(*fhir_result);
+        if (fhir_result.is_ok()) {
+            return imaging_study_resource::from_mapping_struct(fhir_result.unwrap());
         }
     }
 
@@ -964,9 +964,9 @@ resource_result<search_result> imaging_study_handler::search(
             if (pimpl_->mapper_) {
                 auto fhir_result =
                     pimpl_->mapper_->study_to_imaging_study(*study_result);
-                if (fhir_result) {
+                if (fhir_result.is_ok()) {
                     resource =
-                        imaging_study_resource::from_mapping_struct(*fhir_result);
+                        imaging_study_resource::from_mapping_struct(fhir_result.unwrap());
                 }
             } else {
                 resource = dicom_to_fhir_imaging_study(*study_result);
@@ -1006,9 +1006,9 @@ resource_result<search_result> imaging_study_handler::search(
 
         if (pimpl_->mapper_) {
             auto fhir_result = pimpl_->mapper_->study_to_imaging_study(study);
-            if (fhir_result) {
+            if (fhir_result.is_ok()) {
                 resource =
-                    imaging_study_resource::from_mapping_struct(*fhir_result);
+                    imaging_study_resource::from_mapping_struct(fhir_result.unwrap());
             }
         } else {
             resource = dicom_to_fhir_imaging_study(study);

--- a/src/fhir/service_request_resource.cpp
+++ b/src/fhir/service_request_resource.cpp
@@ -1109,10 +1109,10 @@ resource_result<std::unique_ptr<fhir_resource>> service_request_handler::create(
     if (pimpl_->mapper_) {
         auto mwl_result = pimpl_->mapper_->service_request_to_mwl(
             mapping_request, patient);
-        if (mwl_result.has_value()) {
+        if (mwl_result.is_ok()) {
             // Store MWL item
             if (pimpl_->storage_) {
-                pimpl_->storage_->store(resource_id, *mwl_result);
+                pimpl_->storage_->store(resource_id, mwl_result.unwrap());
             }
         }
     }
@@ -1184,8 +1184,8 @@ resource_result<std::unique_ptr<fhir_resource>> service_request_handler::update(
     if (pimpl_->mapper_ && pimpl_->storage_) {
         auto mwl_result = pimpl_->mapper_->service_request_to_mwl(
             mapping_request, patient);
-        if (mwl_result.has_value()) {
-            pimpl_->storage_->update(id, *mwl_result);
+        if (mwl_result.is_ok()) {
+            pimpl_->storage_->update(id, mwl_result.unwrap());
         }
     }
 


### PR DESCRIPTION
## Summary
- Update FHIR resource handlers to use Result<T> API from mapping layer
- Complete phase 4d of mapping layer Result<T> pattern migration

## Changes
- `src/fhir/service_request_resource.cpp`: Updated to use `is_ok()` and `unwrap()` for mwl_result
- `src/fhir/imaging_study_resource.cpp`: Updated to use `is_ok()` and `unwrap()` for fhir_result

## Test plan
- [x] All existing mapper tests pass
- [x] adt_handler_test: Passed
- [x] orm_handler_test: Passed
- [x] dicom_hl7_mapper_test: Passed
- [x] mapper_extended_test: Passed

Closes #246