### PR TITLE
feat(integration): implement logger_adapter module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,12 +150,14 @@ if(BRIDGE_BUILD_HL7)
     )
 endif()
 
-# Integration Module - IExecutor adapter
+# Integration Module - IExecutor and Logger adapters
 # See: https://github.com/kcenon/pacs_bridge/issues/198
+# See: https://github.com/kcenon/pacs_bridge/issues/267
 # Only available in non-standalone build (requires common_system)
 if(NOT BRIDGE_STANDALONE_BUILD)
     list(APPEND PACS_BRIDGE_SOURCES
         src/integration/executor_adapter.cpp
+        src/integration/logger_adapter.cpp
     )
     list(APPEND PACS_BRIDGE_HEADERS
         include/pacs/bridge/integration/executor_adapter.h

--- a/include/pacs/bridge/integration/logger_adapter.h
+++ b/include/pacs/bridge/integration/logger_adapter.h
@@ -108,6 +108,31 @@ public:
 [[nodiscard]] std::unique_ptr<logger_adapter> create_logger(
     std::string_view name);
 
+// Forward declaration for ILogger integration
+namespace kcenon::common::interfaces {
+class ILogger;
+}
+
+/**
+ * @brief Create a logger instance wrapping ILogger
+ * @param logger The ILogger instance to wrap
+ * @return Logger adapter instance
+ */
+[[nodiscard]] std::unique_ptr<logger_adapter> create_logger(
+    std::shared_ptr<kcenon::common::interfaces::ILogger> logger);
+
+/**
+ * @brief Set the global default logger to use an ILogger
+ * @param logger The ILogger instance to use globally
+ */
+void set_default_logger(
+    std::shared_ptr<kcenon::common::interfaces::ILogger> logger);
+
+/**
+ * @brief Reset the global default logger to console fallback
+ */
+void reset_default_logger();
+
 } // namespace pacs::bridge::integration
 
 #endif // PACS_BRIDGE_INTEGRATION_LOGGER_ADAPTER_H

--- a/src/integration/logger_adapter.cpp
+++ b/src/integration/logger_adapter.cpp
@@ -1,0 +1,261 @@
+/**
+ * @file logger_adapter.cpp
+ * @brief Implementation of logger adapter for pacs_bridge
+ *
+ * Bridges logger_adapter interface with common_system's ILogger.
+ * Provides two implementations:
+ *   - ilogger_adapter: wraps ILogger for full ecosystem integration
+ *   - console_logger_adapter: standalone fallback for simpler deployments
+ *
+ * @see include/pacs/bridge/integration/logger_adapter.h
+ * @see https://github.com/kcenon/pacs_bridge/issues/267
+ */
+
+#include "pacs/bridge/integration/logger_adapter.h"
+
+#include <kcenon/common/interfaces/logger_interface.h>
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+
+namespace pacs::bridge::integration {
+
+namespace {
+
+// =============================================================================
+// Log Level Conversion
+// =============================================================================
+
+/**
+ * @brief Convert pacs log_level to kcenon log_level
+ */
+kcenon::common::interfaces::log_level to_kcenon_level(log_level level) {
+    switch (level) {
+        case log_level::trace:
+            return kcenon::common::interfaces::log_level::trace;
+        case log_level::debug:
+            return kcenon::common::interfaces::log_level::debug;
+        case log_level::info:
+            return kcenon::common::interfaces::log_level::info;
+        case log_level::warning:
+            return kcenon::common::interfaces::log_level::warning;
+        case log_level::error:
+            return kcenon::common::interfaces::log_level::error;
+        case log_level::critical:
+            return kcenon::common::interfaces::log_level::critical;
+        default:
+            return kcenon::common::interfaces::log_level::info;
+    }
+}
+
+/**
+ * @brief Convert kcenon log_level to pacs log_level
+ */
+log_level from_kcenon_level(kcenon::common::interfaces::log_level level) {
+    switch (level) {
+        case kcenon::common::interfaces::log_level::trace:
+            return log_level::trace;
+        case kcenon::common::interfaces::log_level::debug:
+            return log_level::debug;
+        case kcenon::common::interfaces::log_level::info:
+            return log_level::info;
+        case kcenon::common::interfaces::log_level::warning:
+            return log_level::warning;
+        case kcenon::common::interfaces::log_level::error:
+            return log_level::error;
+        case kcenon::common::interfaces::log_level::critical:
+            return log_level::critical;
+        case kcenon::common::interfaces::log_level::off:
+            return log_level::critical;
+        default:
+            return log_level::info;
+    }
+}
+
+/**
+ * @brief Get log level name string
+ */
+const char* level_name(log_level level) {
+    switch (level) {
+        case log_level::trace:
+            return "TRACE";
+        case log_level::debug:
+            return "DEBUG";
+        case log_level::info:
+            return "INFO";
+        case log_level::warning:
+            return "WARN";
+        case log_level::error:
+            return "ERROR";
+        case log_level::critical:
+            return "CRIT";
+        default:
+            return "UNKNOWN";
+    }
+}
+
+}  // namespace
+
+// =============================================================================
+// ilogger_adapter - Wraps ILogger
+// =============================================================================
+
+/**
+ * @class ilogger_adapter
+ * @brief Logger adapter that wraps common_system's ILogger
+ *
+ * Provides full integration with the kcenon ecosystem logging infrastructure.
+ */
+class ilogger_adapter : public logger_adapter {
+public:
+    explicit ilogger_adapter(std::shared_ptr<kcenon::common::interfaces::ILogger> logger)
+        : logger_(std::move(logger)) {
+        if (logger_) {
+            current_level_ = from_kcenon_level(logger_->get_level());
+        }
+    }
+
+    void log(log_level level, std::string_view message) override {
+        if (!logger_) {
+            return;
+        }
+
+        if (static_cast<int>(level) < static_cast<int>(current_level_)) {
+            return;
+        }
+
+        logger_->log(to_kcenon_level(level), message);
+    }
+
+    void set_level(log_level level) override {
+        current_level_ = level;
+        if (logger_) {
+            logger_->set_level(to_kcenon_level(level));
+        }
+    }
+
+    [[nodiscard]] log_level get_level() const noexcept override {
+        return current_level_;
+    }
+
+    void flush() override {
+        if (logger_) {
+            logger_->flush();
+        }
+    }
+
+private:
+    std::shared_ptr<kcenon::common::interfaces::ILogger> logger_;
+    log_level current_level_{log_level::info};
+};
+
+// =============================================================================
+// console_logger_adapter - Standalone Fallback
+// =============================================================================
+
+/**
+ * @class console_logger_adapter
+ * @brief Lightweight console logger for standalone deployments
+ *
+ * Provides basic logging to stdout/stderr when ILogger is not available.
+ * Thread-safe output with timestamped messages.
+ */
+class console_logger_adapter : public logger_adapter {
+public:
+    explicit console_logger_adapter(std::string_view name)
+        : name_(name) {}
+
+    void log(log_level level, std::string_view message) override {
+        if (static_cast<int>(level) < static_cast<int>(current_level_)) {
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto now = std::chrono::system_clock::now();
+        auto time = std::chrono::system_clock::to_time_t(now);
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      now.time_since_epoch()) %
+                  1000;
+
+        std::ostringstream oss;
+        oss << std::put_time(std::localtime(&time), "%Y-%m-%d %H:%M:%S") << '.'
+            << std::setfill('0') << std::setw(3) << ms.count() << " ["
+            << level_name(level) << "] ";
+
+        if (!name_.empty()) {
+            oss << "[" << name_ << "] ";
+        }
+
+        oss << message << '\n';
+
+        auto& stream = (level >= log_level::error) ? std::cerr : std::cout;
+        stream << oss.str();
+    }
+
+    void set_level(log_level level) override { current_level_ = level; }
+
+    [[nodiscard]] log_level get_level() const noexcept override {
+        return current_level_;
+    }
+
+    void flush() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::cout.flush();
+        std::cerr.flush();
+    }
+
+private:
+    std::string name_;
+    log_level current_level_{log_level::info};
+    std::mutex mutex_;
+};
+
+// =============================================================================
+// Global Logger Instance
+// =============================================================================
+
+namespace {
+
+std::unique_ptr<logger_adapter> g_default_logger;
+std::mutex g_logger_mutex;
+
+}  // namespace
+
+logger_adapter& get_logger() {
+    std::lock_guard<std::mutex> lock(g_logger_mutex);
+
+    if (!g_default_logger) {
+        g_default_logger = std::make_unique<console_logger_adapter>("pacs_bridge");
+    }
+
+    return *g_default_logger;
+}
+
+std::unique_ptr<logger_adapter> create_logger(std::string_view name) {
+    return std::make_unique<console_logger_adapter>(name);
+}
+
+// =============================================================================
+// Factory Functions for ILogger Integration
+// =============================================================================
+
+std::unique_ptr<logger_adapter> create_logger(
+    std::shared_ptr<kcenon::common::interfaces::ILogger> logger) {
+    return std::make_unique<ilogger_adapter>(std::move(logger));
+}
+
+void set_default_logger(std::shared_ptr<kcenon::common::interfaces::ILogger> logger) {
+    std::lock_guard<std::mutex> lock(g_logger_mutex);
+    g_default_logger = std::make_unique<ilogger_adapter>(std::move(logger));
+}
+
+void reset_default_logger() {
+    std::lock_guard<std::mutex> lock(g_logger_mutex);
+    g_default_logger.reset();
+}
+
+}  // namespace pacs::bridge::integration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -509,8 +509,56 @@ add_integration_test(mpps_persistence_test "integration;pacs_system;mpps;persist
 add_integration_test(pacs_system_e2e_test "integration;pacs_system;e2e;workflow;phase2" 600)
 
 # =============================================================================
-# Integration Module Tests (Issue #198, #210)
+# Integration Module Tests (Issue #198, #210, #267)
 # =============================================================================
+
+# Logger Adapter Tests (Issue #267)
+# Tests logger_adapter implementations for bridge logging
+# Only available when building with kcenon ecosystem dependencies (requires common_system)
+if(NOT BRIDGE_STANDALONE_BUILD)
+    add_executable(logger_adapter_test logger_adapter_test.cpp)
+    target_link_libraries(logger_adapter_test
+        PRIVATE
+            pacs_bridge
+            pacs_bridge_compile_options
+    )
+    if(PACS_BRIDGE_HAS_GTEST)
+        if(TARGET GTest::gtest_main)
+            target_link_libraries(logger_adapter_test PRIVATE GTest::gtest_main GTest::gmock)
+        elseif(TARGET gtest_main)
+            target_link_libraries(logger_adapter_test PRIVATE gtest_main gmock)
+        endif()
+    endif()
+    target_include_directories(logger_adapter_test
+        PRIVATE
+            ${PACS_BRIDGE_TEST_UTILS_DIR}
+    )
+    target_compile_definitions(logger_adapter_test
+        PRIVATE
+            PACS_BRIDGE_TEST_DATA_DIR="${PACS_BRIDGE_TEST_DATA_DIR}"
+    )
+    if(PACS_BRIDGE_HAS_GTEST)
+        include(GoogleTest)
+        gtest_discover_tests(logger_adapter_test
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            PROPERTIES
+                TIMEOUT 60
+                LABELS "unit;integration;logger;phase4"
+        )
+    else()
+        add_test(
+            NAME logger_adapter_test
+            COMMAND logger_adapter_test
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
+        set_tests_properties(logger_adapter_test PROPERTIES
+            TIMEOUT 60
+            LABELS "unit;integration;logger;phase4"
+        )
+    endif()
+else()
+    message(STATUS "Skipping logger_adapter_test: requires common_system ILogger (BRIDGE_STANDALONE_BUILD=OFF)")
+endif()
 
 # Executor Adapter Tests (Issue #210)
 # Tests IExecutor adapter implementations for bridge server
@@ -840,7 +888,8 @@ message(STATUS "  - mpps_persistence_test (Issue #193)")
 message(STATUS "  - pacs_system_e2e_test (Issue #194)")
 message(STATUS "")
 if(NOT BRIDGE_STANDALONE_BUILD)
-    message(STATUS "Integration Module Tests (Issue #198):")
+    message(STATUS "Integration Module Tests (Issue #198, #267):")
+    message(STATUS "  - logger_adapter_test (Issue #267)")
     message(STATUS "  - executor_adapter_test (Issue #210)")
     message(STATUS "")
 endif()

--- a/tests/logger_adapter_test.cpp
+++ b/tests/logger_adapter_test.cpp
@@ -1,0 +1,302 @@
+/**
+ * @file logger_adapter_test.cpp
+ * @brief Unit tests for logger adapter implementations
+ *
+ * Tests for console_logger_adapter, ilogger_adapter, and factory functions.
+ *
+ * @see include/pacs/bridge/integration/logger_adapter.h
+ * @see https://github.com/kcenon/pacs_bridge/issues/267
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "pacs/bridge/integration/logger_adapter.h"
+
+#include "utils/test_helpers.h"
+
+#include <kcenon/common/interfaces/logger_interface.h>
+
+#include <atomic>
+#include <chrono>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+namespace pacs::bridge::integration {
+namespace {
+
+using namespace ::testing;
+using namespace pacs::bridge::test;
+
+// =============================================================================
+// Mock ILogger for Testing
+// =============================================================================
+
+class MockILogger : public kcenon::common::interfaces::ILogger {
+public:
+    MOCK_METHOD(kcenon::common::VoidResult, log,
+                (kcenon::common::interfaces::log_level level, const std::string& message),
+                (override));
+    MOCK_METHOD(kcenon::common::VoidResult, log,
+                (kcenon::common::interfaces::log_level level,
+                 std::string_view message,
+                 const kcenon::common::source_location& loc),
+                (override));
+    MOCK_METHOD(kcenon::common::VoidResult, log,
+                (kcenon::common::interfaces::log_level level,
+                 const std::string& message,
+                 const std::string& file,
+                 int line,
+                 const std::string& function),
+                (override));
+    MOCK_METHOD(kcenon::common::VoidResult, log,
+                (const kcenon::common::interfaces::log_entry& entry), (override));
+    MOCK_METHOD(bool, is_enabled, (kcenon::common::interfaces::log_level level), (const, override));
+    MOCK_METHOD(kcenon::common::VoidResult, set_level,
+                (kcenon::common::interfaces::log_level level), (override));
+    MOCK_METHOD(kcenon::common::interfaces::log_level, get_level, (), (const, override));
+    MOCK_METHOD(kcenon::common::VoidResult, flush, (), (override));
+};
+
+// =============================================================================
+// Console Logger Adapter Tests
+// =============================================================================
+
+class ConsoleLoggerAdapterTest : public pacs_bridge_test {};
+
+TEST_F(ConsoleLoggerAdapterTest, CreateNamedLogger) {
+    auto logger = create_logger("test_logger");
+    ASSERT_NE(logger, nullptr);
+    EXPECT_EQ(logger->get_level(), log_level::info);
+}
+
+TEST_F(ConsoleLoggerAdapterTest, SetAndGetLevel) {
+    auto logger = create_logger("test");
+
+    logger->set_level(log_level::debug);
+    EXPECT_EQ(logger->get_level(), log_level::debug);
+
+    logger->set_level(log_level::error);
+    EXPECT_EQ(logger->get_level(), log_level::error);
+}
+
+TEST_F(ConsoleLoggerAdapterTest, LogLevelFiltering) {
+    auto logger = create_logger("test");
+    logger->set_level(log_level::warning);
+
+    // These should be filtered out (below warning level)
+    logger->trace("trace message");
+    logger->debug("debug message");
+    logger->info("info message");
+
+    // These should pass through
+    logger->warning("warning message");
+    logger->error("error message");
+    logger->critical("critical message");
+}
+
+TEST_F(ConsoleLoggerAdapterTest, FlushDoesNotCrash) {
+    auto logger = create_logger("test");
+    logger->info("message before flush");
+    EXPECT_NO_THROW(logger->flush());
+}
+
+TEST_F(ConsoleLoggerAdapterTest, ConvenienceMethods) {
+    auto logger = create_logger("test");
+    logger->set_level(log_level::trace);
+
+    EXPECT_NO_THROW(logger->trace("trace"));
+    EXPECT_NO_THROW(logger->debug("debug"));
+    EXPECT_NO_THROW(logger->info("info"));
+    EXPECT_NO_THROW(logger->warning("warning"));
+    EXPECT_NO_THROW(logger->error("error"));
+    EXPECT_NO_THROW(logger->critical("critical"));
+}
+
+// =============================================================================
+// ILogger Adapter Tests
+// =============================================================================
+
+class ILoggerAdapterTest : public pacs_bridge_test {};
+
+TEST_F(ILoggerAdapterTest, WrapILogger) {
+    auto mock_logger = std::make_shared<MockILogger>();
+
+    EXPECT_CALL(*mock_logger, get_level())
+        .WillOnce(Return(kcenon::common::interfaces::log_level::info));
+
+    auto adapter = create_logger(mock_logger);
+    ASSERT_NE(adapter, nullptr);
+    EXPECT_EQ(adapter->get_level(), log_level::info);
+}
+
+TEST_F(ILoggerAdapterTest, ForwardsLogCalls) {
+    auto mock_logger = std::make_shared<MockILogger>();
+
+    EXPECT_CALL(*mock_logger, get_level())
+        .WillOnce(Return(kcenon::common::interfaces::log_level::trace));
+
+    EXPECT_CALL(*mock_logger,
+                log(kcenon::common::interfaces::log_level::info, _, _))
+        .WillOnce(Return(kcenon::common::VoidResult(std::monostate{})));
+
+    auto adapter = create_logger(mock_logger);
+    adapter->info("test message");
+}
+
+TEST_F(ILoggerAdapterTest, SetLevelForwardsToILogger) {
+    auto mock_logger = std::make_shared<MockILogger>();
+
+    EXPECT_CALL(*mock_logger, get_level())
+        .WillOnce(Return(kcenon::common::interfaces::log_level::info));
+
+    EXPECT_CALL(*mock_logger, set_level(kcenon::common::interfaces::log_level::debug))
+        .WillOnce(Return(kcenon::common::VoidResult(std::monostate{})));
+
+    auto adapter = create_logger(mock_logger);
+    adapter->set_level(log_level::debug);
+
+    EXPECT_EQ(adapter->get_level(), log_level::debug);
+}
+
+TEST_F(ILoggerAdapterTest, FlushForwardsToILogger) {
+    auto mock_logger = std::make_shared<MockILogger>();
+
+    EXPECT_CALL(*mock_logger, get_level())
+        .WillOnce(Return(kcenon::common::interfaces::log_level::info));
+
+    EXPECT_CALL(*mock_logger, flush())
+        .WillOnce(Return(kcenon::common::VoidResult(std::monostate{})));
+
+    auto adapter = create_logger(mock_logger);
+    adapter->flush();
+}
+
+TEST_F(ILoggerAdapterTest, NullILoggerHandledGracefully) {
+    std::shared_ptr<kcenon::common::interfaces::ILogger> null_logger;
+    auto adapter = create_logger(null_logger);
+
+    ASSERT_NE(adapter, nullptr);
+    EXPECT_NO_THROW(adapter->info("message"));
+    EXPECT_NO_THROW(adapter->flush());
+}
+
+// =============================================================================
+// Global Logger Tests
+// =============================================================================
+
+class GlobalLoggerTest : public pacs_bridge_test {
+protected:
+    void TearDown() override {
+        reset_default_logger();
+        pacs_bridge_test::TearDown();
+    }
+};
+
+TEST_F(GlobalLoggerTest, GetLoggerReturnsNonNull) {
+    auto& logger = get_logger();
+    EXPECT_NO_THROW(logger.info("global logger test"));
+}
+
+TEST_F(GlobalLoggerTest, SetDefaultLoggerWithILogger) {
+    auto mock_logger = std::make_shared<MockILogger>();
+
+    EXPECT_CALL(*mock_logger, get_level())
+        .WillRepeatedly(Return(kcenon::common::interfaces::log_level::info));
+
+    EXPECT_CALL(*mock_logger,
+                log(kcenon::common::interfaces::log_level::info, _, _))
+        .WillOnce(Return(kcenon::common::VoidResult(std::monostate{})));
+
+    set_default_logger(mock_logger);
+
+    auto& logger = get_logger();
+    logger.info("using custom ILogger");
+}
+
+TEST_F(GlobalLoggerTest, ResetDefaultLogger) {
+    auto mock_logger = std::make_shared<MockILogger>();
+
+    EXPECT_CALL(*mock_logger, get_level())
+        .WillRepeatedly(Return(kcenon::common::interfaces::log_level::info));
+
+    set_default_logger(mock_logger);
+    reset_default_logger();
+
+    // After reset, should use console fallback
+    auto& logger = get_logger();
+    EXPECT_NO_THROW(logger.info("back to console logger"));
+}
+
+// =============================================================================
+// Log Level Conversion Tests
+// =============================================================================
+
+class LogLevelConversionTest : public pacs_bridge_test {};
+
+TEST_F(LogLevelConversionTest, AllLevelsSupported) {
+    auto logger = create_logger("test");
+
+    std::vector<log_level> levels = {log_level::trace, log_level::debug,
+                                      log_level::info, log_level::warning,
+                                      log_level::error, log_level::critical};
+
+    for (auto level : levels) {
+        logger->set_level(level);
+        EXPECT_EQ(logger->get_level(), level);
+    }
+}
+
+// =============================================================================
+// Thread Safety Tests
+// =============================================================================
+
+class LoggerThreadSafetyTest : public pacs_bridge_test {};
+
+TEST_F(LoggerThreadSafetyTest, ConcurrentLogging) {
+    auto logger = create_logger("concurrent_test");
+    logger->set_level(log_level::trace);
+
+    std::atomic<int> counter{0};
+    constexpr int logs_per_thread = 100;
+    constexpr int thread_count = 4;
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < thread_count; ++t) {
+        threads.emplace_back([&logger, &counter, t]() {
+            for (int i = 0; i < logs_per_thread; ++i) {
+                logger->info("Thread " + std::to_string(t) + " message " +
+                             std::to_string(i));
+                counter.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_EQ(counter.load(), logs_per_thread * thread_count);
+}
+
+TEST_F(LoggerThreadSafetyTest, ConcurrentGlobalLoggerAccess) {
+    constexpr int thread_count = 4;
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < thread_count; ++t) {
+        threads.emplace_back([t]() {
+            for (int i = 0; i < 25; ++i) {
+                auto& logger = get_logger();
+                logger.info("Thread " + std::to_string(t));
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+}
+
+}  // namespace
+}  // namespace pacs::bridge::integration


### PR DESCRIPTION
## Summary

- Implement `logger_adapter.cpp` bridging `logger_adapter` interface with common_system's ILogger
- Create `ilogger_adapter` class for full ecosystem integration
- Create `console_logger_adapter` as lightweight standalone fallback
- Add factory functions for logger management
- Comprehensive unit tests with thread safety validation

## Changes

| File | Description |
|------|-------------|
| `src/integration/logger_adapter.cpp` | New implementation file (~200 LOC) |
| `include/pacs/bridge/integration/logger_adapter.h` | Extended with ILogger factory functions |
| `CMakeLists.txt` | Added logger_adapter to build |
| `tests/CMakeLists.txt` | Added logger_adapter_test |
| `tests/logger_adapter_test.cpp` | New test file (~280 LOC) |

## Test Plan

- [x] Console logger adapter basic functionality
- [x] Log level filtering
- [x] ILogger wrapper forwarding
- [x] Global logger management
- [x] Thread safety for concurrent logging
- [x] Null ILogger graceful handling

Closes #267
Part of #266