### PR TITLE
refactor(integration): add fallback logic to thread_adapter factory

### DIFF
--- a/src/integration/thread_adapter.cpp
+++ b/src/integration/thread_adapter.cpp
@@ -262,11 +262,28 @@ private:
 };
 
 // =============================================================================
-// Factory Function
+// Factory Function with Fallback
 // =============================================================================
 
+/**
+ * @brief Create thread adapter with automatic fallback
+ *
+ * Attempts to create thread_pool_adapter (wraps thread_system).
+ * Falls back to simple_thread_adapter if thread_system is unavailable.
+ *
+ * @return Unique pointer to thread_adapter implementation
+ */
 std::unique_ptr<thread_adapter> create_thread_adapter() {
-    return std::make_unique<thread_pool_adapter>();
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
+    // Try thread_pool_adapter first for full ecosystem integration
+    try {
+        return std::make_unique<thread_pool_adapter>();
+    } catch (const std::exception&) {
+        // Fall through to simple_thread_adapter
+    }
+#endif
+    // Fallback to standalone implementation
+    return std::make_unique<simple_thread_adapter>();
 }
 
 }  // namespace pacs::bridge::integration


### PR DESCRIPTION
Closes #280

## Summary

Update `create_thread_adapter()` to gracefully fall back to `simple_thread_adapter` when `thread_system` is unavailable or fails to initialize.

This ensures `thread_adapter` works correctly in both:
- **Full ecosystem builds** with thread_system integration
- **Standalone builds** without external dependencies

## What Changed

- Enhanced factory function with try-catch fallback logic
- Uses `PACS_BRIDGE_STANDALONE_BUILD` macro to determine build mode
- Prioritizes `thread_pool_adapter` (thread_system integration) when available
- Falls back to `simple_thread_adapter` for standalone builds

## Test Plan

- [x] Standalone build compiles successfully
- [x] Existing queue operation tests pass (QueueOperationsTest)
- [x] Router tests pass (uses thread_adapter internally)
- [x] No regression in existing functionality

## Related Work

Part of Phase 3a: Replace simple_thread_adapter with thread_system integration (#273)