### PR TITLE
feat(integration): add pacs_adapter interface for standardized PACS integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,15 @@ list(APPEND PACS_BRIDGE_HEADERS
     include/pacs/bridge/integration/mwl_adapter.h
 )
 
+# PACS adapter - standardized PACS integration interface
+# See: https://github.com/kcenon/pacs_bridge/issues/283
+list(APPEND PACS_BRIDGE_SOURCES
+    src/integration/pacs_adapter.cpp
+)
+list(APPEND PACS_BRIDGE_HEADERS
+    include/pacs/bridge/integration/pacs_adapter.h
+)
+
 # MLLP Transport
 list(APPEND PACS_BRIDGE_SOURCES
     src/mllp/mllp_server.cpp

--- a/include/pacs/bridge/integration/pacs_adapter.h
+++ b/include/pacs/bridge/integration/pacs_adapter.h
@@ -1,0 +1,528 @@
+#ifndef PACS_BRIDGE_INTEGRATION_PACS_ADAPTER_H
+#define PACS_BRIDGE_INTEGRATION_PACS_ADAPTER_H
+
+/**
+ * @file pacs_adapter.h
+ * @brief Integration Module - PACS system adapter
+ *
+ * Provides adapters that abstract DICOM operations and enable integration
+ * with pacs_system while maintaining standalone capability. This adapter
+ * consolidates PACS-related functionality scattered across multiple files
+ * (mpps_handler.cpp, mwl_client.cpp) into a consistent interface.
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/283
+ * @see https://github.com/kcenon/pacs_bridge/issues/273
+ * @see docs/SDS_COMPONENTS.md - Section 8: Integration Module
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::bridge::integration {
+
+// =============================================================================
+// Error Codes (-850 to -899)
+// =============================================================================
+
+/**
+ * @brief PACS adapter specific error codes
+ *
+ * Allocated range: -850 to -899
+ */
+enum class pacs_error : int {
+    /** Connection to PACS server failed */
+    connection_failed = -850,
+
+    /** Query execution failed */
+    query_failed = -851,
+
+    /** Store operation failed */
+    store_failed = -852,
+
+    /** Invalid or malformed DICOM dataset */
+    invalid_dataset = -853,
+
+    /** DICOM association failed */
+    association_failed = -854,
+
+    /** Operation timeout */
+    timeout = -855,
+
+    /** Resource not found */
+    not_found = -856,
+
+    /** Duplicate entry detected */
+    duplicate_entry = -857,
+
+    /** Validation failed */
+    validation_failed = -858,
+
+    /** MPPS N-CREATE failed */
+    mpps_create_failed = -859,
+
+    /** MPPS N-SET failed */
+    mpps_update_failed = -860,
+
+    /** MWL query failed */
+    mwl_query_failed = -861,
+
+    /** DICOM storage failed */
+    storage_failed = -862,
+
+    /** Invalid SOP Instance UID */
+    invalid_sop_uid = -863
+};
+
+/**
+ * @brief Convert pacs_error to error code integer
+ */
+[[nodiscard]] constexpr int to_error_code(pacs_error error) noexcept {
+    return static_cast<int>(error);
+}
+
+/**
+ * @brief Get human-readable error message for pacs_error
+ */
+[[nodiscard]] std::string_view to_string(pacs_error error) noexcept;
+
+// =============================================================================
+// DICOM Dataset Abstraction
+// =============================================================================
+
+/**
+ * @brief DICOM dataset representation
+ *
+ * Provides a simplified abstraction over DICOM attributes,
+ * using tag numbers (e.g., 0x00100020 for Patient ID).
+ */
+struct dicom_dataset {
+    /** SOP Class UID (0008,0016) */
+    std::string sop_class_uid;
+
+    /** SOP Instance UID (0008,0018) */
+    std::string sop_instance_uid;
+
+    /** DICOM attributes: Tag -> Value */
+    std::map<uint32_t, std::string> attributes;
+
+    /**
+     * @brief Get string value for a DICOM tag
+     *
+     * @param tag DICOM tag (e.g., 0x00100020 for Patient ID)
+     * @return String value if present, std::nullopt otherwise
+     */
+    [[nodiscard]] std::optional<std::string> get_string(uint32_t tag) const;
+
+    /**
+     * @brief Set string value for a DICOM tag
+     *
+     * @param tag DICOM tag
+     * @param value String value to set
+     */
+    void set_string(uint32_t tag, std::string_view value);
+
+    /**
+     * @brief Check if a tag exists in the dataset
+     */
+    [[nodiscard]] bool has_tag(uint32_t tag) const;
+
+    /**
+     * @brief Remove a tag from the dataset
+     */
+    void remove_tag(uint32_t tag);
+
+    /**
+     * @brief Clear all attributes
+     */
+    void clear();
+};
+
+// =============================================================================
+// MPPS Record Abstraction
+// =============================================================================
+
+/**
+ * @brief Modality Performed Procedure Step (MPPS) record
+ *
+ * Represents an MPPS record with essential DICOM attributes.
+ */
+struct mpps_record {
+    /** Affected SOP Instance UID */
+    std::string sop_instance_uid;
+
+    /** Scheduled Procedure Step ID */
+    std::string scheduled_procedure_step_id;
+
+    /** Performed Procedure Step ID */
+    std::string performed_procedure_step_id;
+
+    /** Performed Station AE Title */
+    std::string performed_station_ae_title;
+
+    /** Performed Station Name */
+    std::string performed_station_name;
+
+    /** Performed Location */
+    std::string performed_location;
+
+    /** Procedure Step Start Date/Time */
+    std::chrono::system_clock::time_point start_datetime;
+
+    /** Procedure Step End Date/Time (optional) */
+    std::optional<std::chrono::system_clock::time_point> end_datetime;
+
+    /** Performed Procedure Step Status: "IN PROGRESS", "COMPLETED", "DISCONTINUED" */
+    std::string status;
+
+    /** Study Instance UID */
+    std::string study_instance_uid;
+
+    /** Patient ID */
+    std::string patient_id;
+
+    /** Patient Name */
+    std::string patient_name;
+
+    /** Series Instance UIDs */
+    std::vector<std::string> series_instance_uids;
+
+    /**
+     * @brief Validate MPPS record fields
+     *
+     * @return true if all required fields are present and valid
+     */
+    [[nodiscard]] bool is_valid() const;
+};
+
+// =============================================================================
+// MWL Item Abstraction
+// =============================================================================
+
+/**
+ * @brief Modality Worklist (MWL) item
+ *
+ * Represents a worklist item from a DICOM Worklist query.
+ */
+struct mwl_item {
+    /** Accession Number */
+    std::string accession_number;
+
+    /** Scheduled Procedure Step ID */
+    std::string scheduled_procedure_step_id;
+
+    /** Requested Procedure ID */
+    std::string requested_procedure_id;
+
+    /** Scheduled Station AE Title */
+    std::string scheduled_station_ae_title;
+
+    /** Scheduled Procedure Step Start Date/Time */
+    std::chrono::system_clock::time_point scheduled_datetime;
+
+    /** Modality */
+    std::string modality;
+
+    /** Patient ID */
+    std::string patient_id;
+
+    /** Patient Name */
+    std::string patient_name;
+
+    /** Study Instance UID */
+    std::string study_instance_uid;
+
+    /**
+     * @brief Validate MWL item fields
+     *
+     * @return true if all required fields are present and valid
+     */
+    [[nodiscard]] bool is_valid() const;
+};
+
+// =============================================================================
+// Query Parameters
+// =============================================================================
+
+/**
+ * @brief Query parameters for MPPS records
+ */
+struct mpps_query_params {
+    /** Patient ID filter (optional) */
+    std::optional<std::string> patient_id;
+
+    /** Study Instance UID filter (optional) */
+    std::optional<std::string> study_instance_uid;
+
+    /** Status filter: "IN PROGRESS", "COMPLETED", "DISCONTINUED" (optional) */
+    std::optional<std::string> status;
+
+    /** Start datetime range (from) */
+    std::optional<std::chrono::system_clock::time_point> from_datetime;
+
+    /** Start datetime range (to) */
+    std::optional<std::chrono::system_clock::time_point> to_datetime;
+
+    /** Maximum number of results */
+    std::size_t max_results = 100;
+};
+
+/**
+ * @brief Query parameters for MWL items
+ */
+struct mwl_query_params {
+    /** Patient ID filter (optional) */
+    std::optional<std::string> patient_id;
+
+    /** Accession Number filter (optional) */
+    std::optional<std::string> accession_number;
+
+    /** Modality filter (optional) */
+    std::optional<std::string> modality;
+
+    /** Scheduled date filter (optional) */
+    std::optional<std::chrono::system_clock::time_point> scheduled_date;
+
+    /** Maximum number of results */
+    std::size_t max_results = 100;
+};
+
+// =============================================================================
+// MPPS Service Adapter
+// =============================================================================
+
+/**
+ * @brief MPPS service adapter interface
+ *
+ * Provides abstraction for DICOM Modality Performed Procedure Step operations.
+ */
+class mpps_adapter {
+public:
+    virtual ~mpps_adapter() = default;
+
+    /**
+     * @brief Create new MPPS record (DICOM N-CREATE)
+     *
+     * @param record MPPS record to create
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, pacs_error>
+        create_mpps(const mpps_record& record) = 0;
+
+    /**
+     * @brief Update existing MPPS record (DICOM N-SET)
+     *
+     * @param record MPPS record with updated fields
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, pacs_error>
+        update_mpps(const mpps_record& record) = 0;
+
+    /**
+     * @brief Query MPPS records
+     *
+     * @param params Query parameters
+     * @return Vector of matching MPPS records or error
+     */
+    [[nodiscard]] virtual std::expected<std::vector<mpps_record>, pacs_error>
+        query_mpps(const mpps_query_params& params) = 0;
+
+    /**
+     * @brief Get single MPPS record by SOP Instance UID
+     *
+     * @param sop_instance_uid SOP Instance UID
+     * @return MPPS record or error
+     */
+    [[nodiscard]] virtual std::expected<mpps_record, pacs_error>
+        get_mpps(std::string_view sop_instance_uid) = 0;
+};
+
+// =============================================================================
+// MWL Service Adapter
+// =============================================================================
+
+/**
+ * @brief Modality Worklist (MWL) service adapter interface
+ *
+ * Provides abstraction for DICOM Worklist Query/Retrieve operations.
+ */
+class mwl_adapter {
+public:
+    virtual ~mwl_adapter() = default;
+
+    /**
+     * @brief Query worklist
+     *
+     * @param params Query parameters
+     * @return Vector of matching MWL items or error
+     */
+    [[nodiscard]] virtual std::expected<std::vector<mwl_item>, pacs_error>
+        query_mwl(const mwl_query_params& params) = 0;
+
+    /**
+     * @brief Get single MWL item by accession number
+     *
+     * @param accession_number Accession Number
+     * @return MWL item or error
+     */
+    [[nodiscard]] virtual std::expected<mwl_item, pacs_error>
+        get_mwl_item(std::string_view accession_number) = 0;
+};
+
+// =============================================================================
+// Storage Service Adapter
+// =============================================================================
+
+/**
+ * @brief DICOM storage service adapter interface
+ *
+ * Provides abstraction for DICOM C-STORE operations.
+ */
+class storage_adapter {
+public:
+    virtual ~storage_adapter() = default;
+
+    /**
+     * @brief Store DICOM dataset
+     *
+     * @param dataset DICOM dataset to store
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, pacs_error>
+        store(const dicom_dataset& dataset) = 0;
+
+    /**
+     * @brief Retrieve DICOM dataset by SOP Instance UID
+     *
+     * @param sop_instance_uid SOP Instance UID
+     * @return DICOM dataset or error
+     */
+    [[nodiscard]] virtual std::expected<dicom_dataset, pacs_error>
+        retrieve(std::string_view sop_instance_uid) = 0;
+
+    /**
+     * @brief Check if dataset exists
+     *
+     * @param sop_instance_uid SOP Instance UID
+     * @return true if exists, false otherwise
+     */
+    [[nodiscard]] virtual bool exists(std::string_view sop_instance_uid) const = 0;
+};
+
+// =============================================================================
+// Combined PACS Adapter
+// =============================================================================
+
+/**
+ * @brief Combined PACS adapter interface
+ *
+ * Provides unified access to all PACS services (MPPS, MWL, Storage).
+ */
+class pacs_adapter {
+public:
+    virtual ~pacs_adapter() = default;
+
+    /**
+     * @brief Get MPPS service adapter
+     */
+    [[nodiscard]] virtual std::shared_ptr<mpps_adapter> get_mpps_adapter() = 0;
+
+    /**
+     * @brief Get MWL service adapter
+     */
+    [[nodiscard]] virtual std::shared_ptr<mwl_adapter> get_mwl_adapter() = 0;
+
+    /**
+     * @brief Get storage service adapter
+     */
+    [[nodiscard]] virtual std::shared_ptr<storage_adapter> get_storage_adapter() = 0;
+
+    /**
+     * @brief Connect to PACS server
+     *
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, pacs_error> connect() = 0;
+
+    /**
+     * @brief Disconnect from PACS server
+     */
+    virtual void disconnect() = 0;
+
+    /**
+     * @brief Check if connected to PACS server
+     */
+    [[nodiscard]] virtual bool is_connected() const = 0;
+
+    /**
+     * @brief Check if PACS adapter is healthy
+     */
+    [[nodiscard]] virtual bool is_healthy() const = 0;
+};
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * @brief PACS adapter configuration
+ */
+struct pacs_config {
+    /** PACS server AE Title */
+    std::string server_ae_title = "PACS_SERVER";
+
+    /** PACS server hostname */
+    std::string server_hostname = "localhost";
+
+    /** PACS server port */
+    uint16_t server_port = 11112;
+
+    /** Calling AE Title */
+    std::string calling_ae_title = "PACS_BRIDGE";
+
+    /** Connection timeout */
+    std::chrono::seconds connection_timeout{30};
+
+    /** Query timeout */
+    std::chrono::seconds query_timeout{60};
+};
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+/**
+ * @brief Create PACS adapter (standalone mode with stub implementation)
+ *
+ * @param config PACS configuration
+ * @return Shared pointer to PACS adapter
+ */
+[[nodiscard]] std::shared_ptr<pacs_adapter>
+create_pacs_adapter(const pacs_config& config);
+
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+// Forward declaration for pacs_system integration
+namespace kcenon::pacs::services {
+class pacs_server;
+}
+
+/**
+ * @brief Create PACS adapter using pacs_system (full integration mode)
+ *
+ * @param server Shared pointer to pacs_server
+ * @return Shared pointer to PACS adapter
+ */
+[[nodiscard]] std::shared_ptr<pacs_adapter> create_pacs_adapter(
+    std::shared_ptr<kcenon::pacs::services::pacs_server> server);
+#endif
+
+}  // namespace pacs::bridge::integration
+
+#endif  // PACS_BRIDGE_INTEGRATION_PACS_ADAPTER_H

--- a/src/integration/CMakeLists.txt
+++ b/src/integration/CMakeLists.txt
@@ -12,3 +12,5 @@
 #   - network_adapter.cpp   (Issue #270)
 #   - thread_adapter.cpp    (Issue #266)
 #   - database_adapter.cpp  (Issue #274)
+#   - mwl_adapter.cpp       (Issue #285)
+#   - pacs_adapter.cpp      (Issue #283)

--- a/src/integration/pacs_adapter.cpp
+++ b/src/integration/pacs_adapter.cpp
@@ -1,0 +1,304 @@
+/**
+ * @file pacs_adapter.cpp
+ * @brief Implementation of PACS adapter for pacs_bridge
+ *
+ * @see include/pacs/bridge/integration/pacs_adapter.h
+ * @see https://github.com/kcenon/pacs_bridge/issues/283
+ */
+
+#include "pacs/bridge/integration/pacs_adapter.h"
+
+#include <algorithm>
+#include <cassert>
+
+namespace pacs::bridge::integration {
+
+// =============================================================================
+// Error Handling
+// =============================================================================
+
+std::string_view to_string(pacs_error error) noexcept {
+    switch (error) {
+        case pacs_error::connection_failed:
+            return "Connection to PACS server failed";
+        case pacs_error::query_failed:
+            return "Query execution failed";
+        case pacs_error::store_failed:
+            return "Store operation failed";
+        case pacs_error::invalid_dataset:
+            return "Invalid or malformed DICOM dataset";
+        case pacs_error::association_failed:
+            return "DICOM association failed";
+        case pacs_error::timeout:
+            return "Operation timeout";
+        case pacs_error::not_found:
+            return "Resource not found";
+        case pacs_error::duplicate_entry:
+            return "Duplicate entry detected";
+        case pacs_error::validation_failed:
+            return "Validation failed";
+        case pacs_error::mpps_create_failed:
+            return "MPPS N-CREATE failed";
+        case pacs_error::mpps_update_failed:
+            return "MPPS N-SET failed";
+        case pacs_error::mwl_query_failed:
+            return "MWL query failed";
+        case pacs_error::storage_failed:
+            return "DICOM storage failed";
+        case pacs_error::invalid_sop_uid:
+            return "Invalid SOP Instance UID";
+        default:
+            return "Unknown PACS error";
+    }
+}
+
+// =============================================================================
+// dicom_dataset Implementation
+// =============================================================================
+
+std::optional<std::string> dicom_dataset::get_string(uint32_t tag) const {
+    auto it = attributes.find(tag);
+    if (it != attributes.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+void dicom_dataset::set_string(uint32_t tag, std::string_view value) {
+    attributes[tag] = std::string(value);
+}
+
+bool dicom_dataset::has_tag(uint32_t tag) const {
+    return attributes.find(tag) != attributes.end();
+}
+
+void dicom_dataset::remove_tag(uint32_t tag) {
+    attributes.erase(tag);
+}
+
+void dicom_dataset::clear() {
+    sop_class_uid.clear();
+    sop_instance_uid.clear();
+    attributes.clear();
+}
+
+// =============================================================================
+// mpps_record Implementation
+// =============================================================================
+
+bool mpps_record::is_valid() const {
+    // Check required fields
+    if (sop_instance_uid.empty()) return false;
+    if (scheduled_procedure_step_id.empty()) return false;
+    if (performed_procedure_step_id.empty()) return false;
+    if (status.empty()) return false;
+
+    // Validate status
+    if (status != "IN PROGRESS" && status != "COMPLETED" && status != "DISCONTINUED") {
+        return false;
+    }
+
+    // COMPLETED status must have end_datetime
+    if (status == "COMPLETED" && !end_datetime.has_value()) {
+        return false;
+    }
+
+    return true;
+}
+
+// =============================================================================
+// mwl_item Implementation
+// =============================================================================
+
+bool mwl_item::is_valid() const {
+    // Check required fields
+    if (accession_number.empty()) return false;
+    if (scheduled_procedure_step_id.empty()) return false;
+    if (patient_id.empty()) return false;
+    if (patient_name.empty()) return false;
+    if (modality.empty()) return false;
+
+    return true;
+}
+
+// =============================================================================
+// Stub MPPS Adapter
+// =============================================================================
+
+/**
+ * @brief Stub implementation of MPPS adapter (standalone mode)
+ *
+ * Provides no-op implementations for testing and standalone usage.
+ */
+class stub_mpps_adapter : public mpps_adapter {
+public:
+    std::expected<void, pacs_error> create_mpps(const mpps_record& record) override {
+        if (!record.is_valid()) {
+            return std::unexpected(pacs_error::validation_failed);
+        }
+        // Stub: no-op implementation
+        return {};
+    }
+
+    std::expected<void, pacs_error> update_mpps(const mpps_record& record) override {
+        if (!record.is_valid()) {
+            return std::unexpected(pacs_error::validation_failed);
+        }
+        // Stub: no-op implementation
+        return {};
+    }
+
+    std::expected<std::vector<mpps_record>, pacs_error> query_mpps(
+        const mpps_query_params& params) override {
+        // Stub: return empty result
+        return std::vector<mpps_record>{};
+    }
+
+    std::expected<mpps_record, pacs_error> get_mpps(
+        std::string_view sop_instance_uid) override {
+        if (sop_instance_uid.empty()) {
+            return std::unexpected(pacs_error::invalid_sop_uid);
+        }
+        // Stub: not found
+        return std::unexpected(pacs_error::not_found);
+    }
+};
+
+// =============================================================================
+// Stub MWL Adapter
+// =============================================================================
+
+/**
+ * @brief Stub implementation of MWL adapter (standalone mode)
+ *
+ * Provides no-op implementations for testing and standalone usage.
+ */
+class stub_mwl_adapter : public mwl_adapter {
+public:
+    std::expected<std::vector<mwl_item>, pacs_error> query_mwl(
+        const mwl_query_params& params) override {
+        // Stub: return empty result
+        return std::vector<mwl_item>{};
+    }
+
+    std::expected<mwl_item, pacs_error> get_mwl_item(
+        std::string_view accession_number) override {
+        if (accession_number.empty()) {
+            return std::unexpected(pacs_error::validation_failed);
+        }
+        // Stub: not found
+        return std::unexpected(pacs_error::not_found);
+    }
+};
+
+// =============================================================================
+// Stub Storage Adapter
+// =============================================================================
+
+/**
+ * @brief Stub implementation of storage adapter (standalone mode)
+ *
+ * Provides no-op implementations for testing and standalone usage.
+ */
+class stub_storage_adapter : public storage_adapter {
+public:
+    std::expected<void, pacs_error> store(const dicom_dataset& dataset) override {
+        if (dataset.sop_instance_uid.empty()) {
+            return std::unexpected(pacs_error::invalid_dataset);
+        }
+        // Stub: no-op implementation
+        return {};
+    }
+
+    std::expected<dicom_dataset, pacs_error> retrieve(
+        std::string_view sop_instance_uid) override {
+        if (sop_instance_uid.empty()) {
+            return std::unexpected(pacs_error::invalid_sop_uid);
+        }
+        // Stub: not found
+        return std::unexpected(pacs_error::not_found);
+    }
+
+    bool exists(std::string_view sop_instance_uid) const override {
+        // Stub: always return false
+        return false;
+    }
+};
+
+// =============================================================================
+// Stub PACS Adapter
+// =============================================================================
+
+/**
+ * @brief Stub implementation of PACS adapter (standalone mode)
+ *
+ * Provides a complete stub implementation for standalone usage
+ * without pacs_system integration.
+ */
+class stub_pacs_adapter : public pacs_adapter {
+public:
+    explicit stub_pacs_adapter(const pacs_config& config)
+        : config_(config)
+        , mpps_adapter_(std::make_shared<stub_mpps_adapter>())
+        , mwl_adapter_(std::make_shared<stub_mwl_adapter>())
+        , storage_adapter_(std::make_shared<stub_storage_adapter>())
+        , connected_(false) {}
+
+    std::shared_ptr<mpps_adapter> get_mpps_adapter() override {
+        return mpps_adapter_;
+    }
+
+    std::shared_ptr<mwl_adapter> get_mwl_adapter() override {
+        return mwl_adapter_;
+    }
+
+    std::shared_ptr<storage_adapter> get_storage_adapter() override {
+        return storage_adapter_;
+    }
+
+    std::expected<void, pacs_error> connect() override {
+        // Stub: simulate successful connection
+        connected_ = true;
+        return {};
+    }
+
+    void disconnect() override {
+        // Stub: simulate disconnection
+        connected_ = false;
+    }
+
+    bool is_connected() const override {
+        return connected_;
+    }
+
+    bool is_healthy() const override {
+        // Stub: always healthy if connected
+        return connected_;
+    }
+
+private:
+    pacs_config config_;
+    std::shared_ptr<stub_mpps_adapter> mpps_adapter_;
+    std::shared_ptr<stub_mwl_adapter> mwl_adapter_;
+    std::shared_ptr<stub_storage_adapter> storage_adapter_;
+    bool connected_;
+};
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+std::shared_ptr<pacs_adapter> create_pacs_adapter(const pacs_config& config) {
+    return std::make_shared<stub_pacs_adapter>(config);
+}
+
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+std::shared_ptr<pacs_adapter> create_pacs_adapter(
+    std::shared_ptr<kcenon::pacs::services::pacs_server> server) {
+    // TODO: Implement pacs_system integration in Phase 4d
+    // For now, return stub adapter
+    return std::make_shared<stub_pacs_adapter>(pacs_config{});
+}
+#endif
+
+}  // namespace pacs::bridge::integration


### PR DESCRIPTION
Closes #283

## Summary

This PR implements the `pacs_adapter` interface that provides a consistent abstraction over DICOM operations (MPPS, MWL, Storage), enabling full pacs_system integration while maintaining standalone capability.

### Changes Made

**New Header File: `pacs_adapter.h`**
- Define DICOM data structures
  - `dicom_dataset`: DICOM attribute representation with tag-based access
  - `mpps_record`: MPPS record with validation
  - `mwl_item`: Modality worklist item with validation
- Define query parameter structures
  - `mpps_query_params`: Query parameters for MPPS records
  - `mwl_query_params`: Query parameters for MWL items
- Define service adapter interfaces
  - `mpps_adapter`: MPPS N-CREATE, N-SET, and query operations
  - `mwl_adapter`: Worklist query/retrieve operations
  - `storage_adapter`: DICOM C-STORE operations
- Define combined `pacs_adapter` interface
  - Service access methods (get_mpps_adapter, get_mwl_adapter, get_storage_adapter)
  - Connection management (connect, disconnect, is_connected, is_healthy)
- Define error codes (-850 to -899)

**New Source File: `pacs_adapter.cpp`**
- Implement `stub_mpps_adapter` for standalone mode
- Implement `stub_mwl_adapter` for standalone mode
- Implement `stub_storage_adapter` for standalone mode
- Implement `stub_pacs_adapter` combining all services
- Add validation methods for `mpps_record` and `mwl_item`
- Add error-to-string conversion function

**Build System Updates**
- Update root `CMakeLists.txt` to include pacs_adapter sources
- Update `src/integration/CMakeLists.txt` documentation

### Benefits

1. **Clear Separation of Concerns**: Consolidates scattered PACS functionality from `mpps_handler.cpp` and `mwl_client.cpp`
2. **Testability**: Provides stub implementations for standalone testing
3. **Extensibility**: Ready for pacs_system integration (Phase 4d)
4. **Consistent Interface**: Standard error handling and data structures across PACS operations

## Test Plan

- [x] Build succeeds without errors
- [x] All integration tests pass (mpps_integration_test, ecosystem_integration_test, monitoring_integration_test)
- [x] No compilation warnings introduced

### Next Steps

- [ ] Phase 4b: Migrate mpps_handler to use pacs_adapter
- [ ] Phase 4c: Migrate mwl_client to use pacs_adapter
- [ ] Phase 4d: Implement pacs_system integration for pacs_adapter