### PR TITLE
feat(mllp): add network adapter interface and BSD socket implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,11 +203,14 @@ list(APPEND PACS_BRIDGE_HEADERS
 
 # MLLP Transport
 list(APPEND PACS_BRIDGE_SOURCES
+    src/mllp/mllp_network_adapter.cpp
+    src/mllp/bsd_mllp_server.cpp
     src/mllp/mllp_server.cpp
     src/mllp/mllp_client.cpp
 )
 list(APPEND PACS_BRIDGE_HEADERS
     include/pacs/bridge/mllp/mllp_types.h
+    include/pacs/bridge/mllp/mllp_network_adapter.h
     include/pacs/bridge/mllp/mllp_server.h
     include/pacs/bridge/mllp/mllp_client.h
 )

--- a/include/pacs/bridge/mllp/mllp_network_adapter.h
+++ b/include/pacs/bridge/mllp/mllp_network_adapter.h
@@ -1,0 +1,322 @@
+#ifndef PACS_BRIDGE_MLLP_MLLP_NETWORK_ADAPTER_H
+#define PACS_BRIDGE_MLLP_MLLP_NETWORK_ADAPTER_H
+
+/**
+ * @file mllp_network_adapter.h
+ * @brief Network layer abstraction for MLLP server
+ *
+ * Provides abstract interfaces for network operations, enabling different
+ * transport implementations (BSD sockets, TLS) to be used interchangeably
+ * with the MLLP server.
+ *
+ * This abstraction separates protocol handling from network transport,
+ * improving testability and enabling future transport options.
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/277
+ */
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <functional>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace pacs::bridge::mllp {
+
+// =============================================================================
+// Error Codes
+// =============================================================================
+
+/**
+ * @brief Network-specific error codes for MLLP transport
+ */
+enum class network_error : int {
+    /** Operation timed out */
+    timeout = -980,
+
+    /** Connection closed by peer */
+    connection_closed = -981,
+
+    /** Socket operation failed */
+    socket_error = -982,
+
+    /** Failed to bind or listen on port */
+    bind_failed = -983,
+
+    /** TLS handshake failed */
+    tls_handshake_failed = -984,
+
+    /** Invalid configuration */
+    invalid_config = -985,
+
+    /** Operation would block (non-blocking I/O) */
+    would_block = -986,
+
+    /** Connection refused by peer */
+    connection_refused = -987
+};
+
+/**
+ * @brief Get human-readable description of network error
+ */
+[[nodiscard]] constexpr const char* to_string(network_error error) noexcept {
+    switch (error) {
+        case network_error::timeout:
+            return "Operation timed out";
+        case network_error::connection_closed:
+            return "Connection closed by peer";
+        case network_error::socket_error:
+            return "Socket operation failed";
+        case network_error::bind_failed:
+            return "Failed to bind or listen on port";
+        case network_error::tls_handshake_failed:
+            return "TLS handshake failed";
+        case network_error::invalid_config:
+            return "Invalid configuration";
+        case network_error::would_block:
+            return "Operation would block";
+        case network_error::connection_refused:
+            return "Connection refused by peer";
+        default:
+            return "Unknown network error";
+    }
+}
+
+// =============================================================================
+// Configuration Structures
+// =============================================================================
+
+/**
+ * @brief Server configuration for network adapter
+ */
+struct server_config {
+    /** Port to listen on */
+    uint16_t port = 2575;
+
+    /** Bind address (empty = all interfaces) */
+    std::string bind_address;
+
+    /** Maximum pending connections in listen backlog */
+    int backlog = 128;
+
+    /** Socket receive buffer size (0 = system default) */
+    size_t recv_buffer_size = 0;
+
+    /** Socket send buffer size (0 = system default) */
+    size_t send_buffer_size = 0;
+
+    /** Enable TCP keep-alive */
+    bool keep_alive = true;
+
+    /** TCP keep-alive idle time (seconds) */
+    int keep_alive_idle = 60;
+
+    /** TCP keep-alive interval (seconds) */
+    int keep_alive_interval = 10;
+
+    /** TCP keep-alive probe count */
+    int keep_alive_count = 3;
+
+    /** Disable Nagle's algorithm (enable TCP_NODELAY) */
+    bool no_delay = true;
+
+    /** Reuse address (SO_REUSEADDR) */
+    bool reuse_addr = true;
+
+    /** Validate configuration */
+    [[nodiscard]] bool is_valid() const noexcept {
+        return port > 0 && backlog > 0;
+    }
+};
+
+/**
+ * @brief Session statistics
+ */
+struct session_stats {
+    /** Total bytes received on this session */
+    size_t bytes_received = 0;
+
+    /** Total bytes sent on this session */
+    size_t bytes_sent = 0;
+
+    /** Messages received */
+    size_t messages_received = 0;
+
+    /** Messages sent */
+    size_t messages_sent = 0;
+
+    /** Session start time */
+    std::chrono::system_clock::time_point connected_at;
+
+    /** Last activity time */
+    std::chrono::system_clock::time_point last_activity;
+};
+
+// =============================================================================
+// Session Interface
+// =============================================================================
+
+/**
+ * @brief Abstract interface for a network session (connection)
+ *
+ * Represents a single TCP connection with send/receive capabilities.
+ * Implementations handle the underlying transport (BSD sockets, TLS, etc.).
+ */
+class mllp_session {
+public:
+    virtual ~mllp_session() = default;
+
+    // Non-copyable
+    mllp_session(const mllp_session&) = delete;
+    mllp_session& operator=(const mllp_session&) = delete;
+
+    // Movable
+    mllp_session(mllp_session&&) = default;
+    mllp_session& operator=(mllp_session&&) = default;
+
+    /**
+     * @brief Receive data from the connection
+     *
+     * Attempts to receive up to max_bytes within the specified timeout.
+     * Returns partial data if less than max_bytes is available.
+     *
+     * @param max_bytes Maximum bytes to receive
+     * @param timeout Maximum time to wait for data
+     * @return Received data or error
+     */
+    [[nodiscard]] virtual std::expected<std::vector<uint8_t>, network_error>
+    receive(size_t max_bytes, std::chrono::milliseconds timeout) = 0;
+
+    /**
+     * @brief Send data over the connection
+     *
+     * Sends all bytes in the provided span. Blocks until all data is sent
+     * or an error occurs.
+     *
+     * @param data Data to send
+     * @return Number of bytes sent, or error
+     */
+    [[nodiscard]] virtual std::expected<size_t, network_error>
+    send(std::span<const uint8_t> data) = 0;
+
+    /**
+     * @brief Close the connection
+     *
+     * Gracefully closes the connection. After calling close(), the session
+     * should not be used for further I/O operations.
+     */
+    virtual void close() = 0;
+
+    /**
+     * @brief Check if the connection is still open
+     */
+    [[nodiscard]] virtual bool is_open() const noexcept = 0;
+
+    /**
+     * @brief Get session statistics
+     */
+    [[nodiscard]] virtual session_stats get_stats() const noexcept = 0;
+
+    /**
+     * @brief Get remote peer address
+     */
+    [[nodiscard]] virtual std::string remote_address() const noexcept = 0;
+
+    /**
+     * @brief Get remote peer port
+     */
+    [[nodiscard]] virtual uint16_t remote_port() const noexcept = 0;
+
+    /**
+     * @brief Get unique session identifier
+     */
+    [[nodiscard]] virtual uint64_t session_id() const noexcept = 0;
+
+protected:
+    mllp_session() = default;
+};
+
+// =============================================================================
+// Server Adapter Interface
+// =============================================================================
+
+/**
+ * @brief Abstract interface for MLLP server network adapter
+ *
+ * Manages the server socket and accepts incoming connections.
+ * Implementations handle platform-specific networking (BSD sockets, Winsock).
+ */
+class mllp_server_adapter {
+public:
+    /**
+     * @brief Callback type for new connections
+     *
+     * Called when a new connection is accepted. The callback receives
+     * ownership of the session.
+     *
+     * @param session Newly accepted connection
+     */
+    using on_connection_callback =
+        std::function<void(std::unique_ptr<mllp_session> session)>;
+
+    virtual ~mllp_server_adapter() = default;
+
+    // Non-copyable, non-movable (manages server socket)
+    mllp_server_adapter(const mllp_server_adapter&) = delete;
+    mllp_server_adapter& operator=(const mllp_server_adapter&) = delete;
+    mllp_server_adapter(mllp_server_adapter&&) = delete;
+    mllp_server_adapter& operator=(mllp_server_adapter&&) = delete;
+
+    /**
+     * @brief Start the server and begin listening
+     *
+     * Binds to the configured port and starts accepting connections.
+     * The on_connection callback will be invoked for each new connection.
+     *
+     * @return Success or error
+     */
+    [[nodiscard]] virtual std::expected<void, network_error> start() = 0;
+
+    /**
+     * @brief Stop the server
+     *
+     * Stops accepting new connections. Existing connections are not affected.
+     *
+     * @param wait_for_connections If true, waits for active connections to close
+     */
+    virtual void stop(bool wait_for_connections = true) = 0;
+
+    /**
+     * @brief Check if server is running
+     */
+    [[nodiscard]] virtual bool is_running() const noexcept = 0;
+
+    /**
+     * @brief Get the listening port
+     */
+    [[nodiscard]] virtual uint16_t port() const noexcept = 0;
+
+    /**
+     * @brief Set the callback for new connections
+     *
+     * Must be called before start().
+     *
+     * @param callback Function to call for each new connection
+     */
+    virtual void on_connection(on_connection_callback callback) = 0;
+
+    /**
+     * @brief Get current active session count
+     */
+    [[nodiscard]] virtual size_t active_session_count() const noexcept = 0;
+
+protected:
+    mllp_server_adapter() = default;
+};
+
+}  // namespace pacs::bridge::mllp
+
+#endif  // PACS_BRIDGE_MLLP_MLLP_NETWORK_ADAPTER_H

--- a/src/mllp/bsd_mllp_server.cpp
+++ b/src/mllp/bsd_mllp_server.cpp
@@ -1,0 +1,589 @@
+/**
+ * @file bsd_mllp_server.cpp
+ * @brief BSD socket implementation of MLLP network adapter
+ *
+ * Platform-specific socket implementation supporting:
+ * - Windows (Winsock2)
+ * - POSIX systems (Linux, macOS, BSD)
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/305
+ */
+
+#include "bsd_mllp_server.h"
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+// Platform-specific headers
+#ifdef _WIN32
+// Windows socket headers already included in bsd_mllp_server.h
+#pragma comment(lib, "ws2_32.lib")
+// ssize_t is POSIX-specific, define for Windows
+using ssize_t = std::ptrdiff_t;
+#else
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+namespace pacs::bridge::mllp {
+
+namespace {
+
+/**
+ * @brief Get last socket error code in a platform-independent way
+ */
+[[nodiscard]] int get_last_socket_error() {
+#ifdef _WIN32
+    return WSAGetLastError();
+#else
+    return errno;
+#endif
+}
+
+/**
+ * @brief Check if error indicates operation would block
+ */
+[[nodiscard]] bool is_would_block_error(int error) {
+#ifdef _WIN32
+    return error == WSAEWOULDBLOCK;
+#else
+    return error == EWOULDBLOCK || error == EAGAIN;
+#endif
+}
+
+/**
+ * @brief Close socket in platform-specific way
+ */
+void close_socket(socket_t sock) {
+    if (sock == INVALID_SOCKET_VALUE) {
+        return;
+    }
+#ifdef _WIN32
+    closesocket(sock);
+#else
+    ::close(sock);
+#endif
+}
+
+}  // anonymous namespace
+
+// =============================================================================
+// BSD Session Implementation
+// =============================================================================
+
+bsd_mllp_session::bsd_mllp_session(socket_t sock, uint64_t session_id,
+                                   std::string remote_addr,
+                                   uint16_t remote_port)
+    : socket_(sock),
+      session_id_(session_id),
+      remote_addr_(std::move(remote_addr)),
+      remote_port_(remote_port) {
+    stats_.connected_at = std::chrono::system_clock::now();
+    stats_.last_activity = stats_.connected_at;
+}
+
+bsd_mllp_session::~bsd_mllp_session() { close(); }
+
+std::expected<std::vector<uint8_t>, network_error>
+bsd_mllp_session::receive(size_t max_bytes,
+                          std::chrono::milliseconds timeout) {
+    if (!is_open_) {
+        return std::unexpected(network_error::connection_closed);
+    }
+
+    // Wait for data to be available
+    auto ready_result = wait_for_io(true, timeout);
+    if (!ready_result) {
+        return std::unexpected(ready_result.error());
+    }
+
+    if (!ready_result.value()) {
+        // Timeout occurred
+        return std::unexpected(network_error::timeout);
+    }
+
+    // Receive data
+    std::vector<uint8_t> buffer(max_bytes);
+
+#ifdef _WIN32
+    int bytes_received =
+        ::recv(socket_, reinterpret_cast<char*>(buffer.data()),
+               static_cast<int>(max_bytes), 0);
+#else
+    ssize_t bytes_received = ::recv(socket_, buffer.data(), max_bytes, 0);
+#endif
+
+    if (bytes_received < 0) {
+        int error = get_last_socket_error();
+        if (is_would_block_error(error)) {
+            return std::unexpected(network_error::would_block);
+        }
+        is_open_ = false;
+        return std::unexpected(network_error::socket_error);
+    }
+
+    if (bytes_received == 0) {
+        // Connection closed by peer
+        is_open_ = false;
+        return std::unexpected(network_error::connection_closed);
+    }
+
+    // Update statistics
+    {
+        std::lock_guard lock(stats_mutex_);
+        stats_.bytes_received += static_cast<size_t>(bytes_received);
+        stats_.last_activity = std::chrono::system_clock::now();
+    }
+
+    buffer.resize(static_cast<size_t>(bytes_received));
+    return buffer;
+}
+
+std::expected<size_t, network_error>
+bsd_mllp_session::send(std::span<const uint8_t> data) {
+    if (!is_open_) {
+        return std::unexpected(network_error::connection_closed);
+    }
+
+    size_t total_sent = 0;
+    const uint8_t* ptr = data.data();
+    size_t remaining = data.size();
+
+    while (remaining > 0) {
+#ifdef _WIN32
+        int sent = ::send(socket_, reinterpret_cast<const char*>(ptr),
+                          static_cast<int>(remaining), 0);
+#else
+        ssize_t sent = ::send(socket_, ptr, remaining, 0);
+#endif
+
+        if (sent < 0) {
+            int error = get_last_socket_error();
+            if (is_would_block_error(error)) {
+                // Wait for socket to be writable
+                auto ready_result =
+                    wait_for_io(false, std::chrono::milliseconds{5000});
+                if (!ready_result || !ready_result.value()) {
+                    return std::unexpected(network_error::timeout);
+                }
+                continue;  // Retry send
+            }
+            is_open_ = false;
+            return std::unexpected(network_error::socket_error);
+        }
+
+        if (sent == 0) {
+            // Connection closed
+            is_open_ = false;
+            return std::unexpected(network_error::connection_closed);
+        }
+
+        total_sent += static_cast<size_t>(sent);
+        ptr += sent;
+        remaining -= static_cast<size_t>(sent);
+    }
+
+    // Update statistics
+    {
+        std::lock_guard lock(stats_mutex_);
+        stats_.bytes_sent += total_sent;
+        stats_.last_activity = std::chrono::system_clock::now();
+    }
+
+    return total_sent;
+}
+
+void bsd_mllp_session::close() {
+    if (is_open_.exchange(false)) {
+        close_socket(socket_);
+        socket_ = INVALID_SOCKET_VALUE;
+    }
+}
+
+bool bsd_mllp_session::is_open() const noexcept { return is_open_; }
+
+session_stats bsd_mllp_session::get_stats() const noexcept {
+    std::lock_guard lock(stats_mutex_);
+    return stats_;
+}
+
+std::string bsd_mllp_session::remote_address() const noexcept {
+    return remote_addr_;
+}
+
+uint16_t bsd_mllp_session::remote_port() const noexcept {
+    return remote_port_;
+}
+
+uint64_t bsd_mllp_session::session_id() const noexcept { return session_id_; }
+
+std::expected<void, network_error>
+bsd_mllp_session::set_nonblocking(bool enable) {
+#ifdef _WIN32
+    u_long mode = enable ? 1 : 0;
+    if (ioctlsocket(socket_, FIONBIO, &mode) != 0) {
+        return std::unexpected(network_error::socket_error);
+    }
+#else
+    int flags = fcntl(socket_, F_GETFL, 0);
+    if (flags < 0) {
+        return std::unexpected(network_error::socket_error);
+    }
+
+    if (enable) {
+        flags |= O_NONBLOCK;
+    } else {
+        flags &= ~O_NONBLOCK;
+    }
+
+    if (fcntl(socket_, F_SETFL, flags) < 0) {
+        return std::unexpected(network_error::socket_error);
+    }
+#endif
+
+    return {};
+}
+
+std::expected<bool, network_error>
+bsd_mllp_session::wait_for_io(bool for_read,
+                              std::chrono::milliseconds timeout) {
+#ifdef _WIN32
+    // Use select() on Windows
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(socket_, &fds);
+
+    struct timeval tv;
+    tv.tv_sec = static_cast<long>(timeout.count() / 1000);
+    tv.tv_usec = static_cast<long>((timeout.count() % 1000) * 1000);
+
+    int result;
+    if (for_read) {
+        result = select(0, &fds, nullptr, nullptr, &tv);
+    } else {
+        result = select(0, nullptr, &fds, nullptr, &tv);
+    }
+
+    if (result < 0) {
+        return std::unexpected(network_error::socket_error);
+    }
+
+    return result > 0;
+#else
+    // Use poll() on POSIX
+    struct pollfd pfd;
+    pfd.fd = socket_;
+    pfd.events = for_read ? POLLIN : POLLOUT;
+    pfd.revents = 0;
+
+    int timeout_ms = static_cast<int>(timeout.count());
+    int result = poll(&pfd, 1, timeout_ms);
+
+    if (result < 0) {
+        return std::unexpected(network_error::socket_error);
+    }
+
+    if (result == 0) {
+        // Timeout
+        return false;
+    }
+
+    if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+        is_open_ = false;
+        return std::unexpected(network_error::connection_closed);
+    }
+
+    return (pfd.revents & pfd.events) != 0;
+#endif
+}
+
+// =============================================================================
+// BSD Server Implementation
+// =============================================================================
+
+bsd_mllp_server::bsd_mllp_server(const server_config& config)
+    : config_(config) {}
+
+bsd_mllp_server::~bsd_mllp_server() {
+    stop(false);
+    cleanup_networking();
+}
+
+std::expected<void, network_error> bsd_mllp_server::start() {
+    std::lock_guard lock(state_mutex_);
+
+    if (running_) {
+        return std::unexpected(network_error::socket_error);
+    }
+
+    if (!config_.is_valid()) {
+        return std::unexpected(network_error::invalid_config);
+    }
+
+    // Initialize platform-specific networking
+    if (auto result = initialize_networking(); !result) {
+        return result;
+    }
+
+    // Create server socket
+    if (auto result = create_server_socket(); !result) {
+        cleanup_networking();
+        return result;
+    }
+
+    // Start accept loop
+    running_ = true;
+    stop_requested_ = false;
+    accept_thread_ = std::thread([this] { accept_loop(); });
+
+    return {};
+}
+
+void bsd_mllp_server::stop(bool wait_for_connections) {
+    {
+        std::lock_guard lock(state_mutex_);
+        if (!running_) {
+            return;
+        }
+        stop_requested_ = true;
+    }
+
+    // Close server socket to unblock accept
+    close_socket(server_socket_);
+    server_socket_ = INVALID_SOCKET_VALUE;
+
+    // Wait for accept thread
+    if (accept_thread_.joinable()) {
+        accept_thread_.join();
+    }
+
+    // Wait for active sessions to close if requested
+    if (wait_for_connections) {
+        auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds{30};
+        while (std::chrono::steady_clock::now() < deadline &&
+               active_sessions_ > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+        }
+    }
+
+    running_ = false;
+}
+
+bool bsd_mllp_server::is_running() const noexcept { return running_; }
+
+uint16_t bsd_mllp_server::port() const noexcept { return config_.port; }
+
+void bsd_mllp_server::on_connection(on_connection_callback callback) {
+    connection_callback_ = std::move(callback);
+}
+
+size_t bsd_mllp_server::active_session_count() const noexcept {
+    return active_sessions_;
+}
+
+std::expected<void, network_error> bsd_mllp_server::initialize_networking() {
+#ifdef _WIN32
+    WSADATA wsa_data;
+    int result = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    if (result != 0) {
+        return std::unexpected(network_error::socket_error);
+    }
+    winsock_initialized_ = true;
+#endif
+    return {};
+}
+
+void bsd_mllp_server::cleanup_networking() {
+#ifdef _WIN32
+    if (winsock_initialized_) {
+        WSACleanup();
+        winsock_initialized_ = false;
+    }
+#endif
+}
+
+std::expected<void, network_error> bsd_mllp_server::create_server_socket() {
+    // Create socket
+    server_socket_ = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (server_socket_ == INVALID_SOCKET_VALUE) {
+        return std::unexpected(network_error::socket_error);
+    }
+
+    // Configure socket options
+    if (auto result = configure_socket_options(server_socket_); !result) {
+        close_socket(server_socket_);
+        server_socket_ = INVALID_SOCKET_VALUE;
+        return result;
+    }
+
+    // Bind to address
+    struct sockaddr_in server_addr;
+    std::memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(config_.port);
+
+    if (config_.bind_address.empty()) {
+        server_addr.sin_addr.s_addr = INADDR_ANY;
+    } else {
+        if (inet_pton(AF_INET, config_.bind_address.c_str(),
+                      &server_addr.sin_addr) <= 0) {
+            close_socket(server_socket_);
+            server_socket_ = INVALID_SOCKET_VALUE;
+            return std::unexpected(network_error::invalid_config);
+        }
+    }
+
+    if (bind(server_socket_, reinterpret_cast<struct sockaddr*>(&server_addr),
+             sizeof(server_addr)) < 0) {
+        close_socket(server_socket_);
+        server_socket_ = INVALID_SOCKET_VALUE;
+        return std::unexpected(network_error::bind_failed);
+    }
+
+    // Listen for connections
+    if (listen(server_socket_, config_.backlog) < 0) {
+        close_socket(server_socket_);
+        server_socket_ = INVALID_SOCKET_VALUE;
+        return std::unexpected(network_error::bind_failed);
+    }
+
+    return {};
+}
+
+std::expected<void, network_error>
+bsd_mllp_server::configure_socket_options(socket_t sock) {
+    // SO_REUSEADDR
+    if (config_.reuse_addr) {
+        int reuse = 1;
+        if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
+                       reinterpret_cast<const char*>(&reuse),
+                       sizeof(reuse)) < 0) {
+            return std::unexpected(network_error::socket_error);
+        }
+    }
+
+    // TCP_NODELAY (disable Nagle's algorithm)
+    if (config_.no_delay) {
+        int nodelay = 1;
+        if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
+                       reinterpret_cast<const char*>(&nodelay),
+                       sizeof(nodelay)) < 0) {
+            return std::unexpected(network_error::socket_error);
+        }
+    }
+
+    // SO_KEEPALIVE
+    if (config_.keep_alive) {
+        int keepalive = 1;
+        if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE,
+                       reinterpret_cast<const char*>(&keepalive),
+                       sizeof(keepalive)) < 0) {
+            return std::unexpected(network_error::socket_error);
+        }
+
+#if defined(__linux__)
+        // Linux keep-alive settings
+        if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE,
+                       &config_.keep_alive_idle,
+                       sizeof(config_.keep_alive_idle)) < 0) {
+            return std::unexpected(network_error::socket_error);
+        }
+
+        if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL,
+                       &config_.keep_alive_interval,
+                       sizeof(config_.keep_alive_interval)) < 0) {
+            return std::unexpected(network_error::socket_error);
+        }
+
+        if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT,
+                       &config_.keep_alive_count,
+                       sizeof(config_.keep_alive_count)) < 0) {
+            return std::unexpected(network_error::socket_error);
+        }
+#elif defined(__APPLE__)
+        // macOS keep-alive settings (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
+        if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPALIVE,
+                       &config_.keep_alive_idle,
+                       sizeof(config_.keep_alive_idle)) < 0) {
+            return std::unexpected(network_error::socket_error);
+        }
+        // Note: macOS doesn't support TCP_KEEPINTVL and TCP_KEEPCNT
+#endif
+    }
+
+    // Socket buffer sizes
+    if (config_.recv_buffer_size > 0) {
+        int size = static_cast<int>(config_.recv_buffer_size);
+        setsockopt(sock, SOL_SOCKET, SO_RCVBUF,
+                   reinterpret_cast<const char*>(&size), sizeof(size));
+    }
+
+    if (config_.send_buffer_size > 0) {
+        int size = static_cast<int>(config_.send_buffer_size);
+        setsockopt(sock, SOL_SOCKET, SO_SNDBUF,
+                   reinterpret_cast<const char*>(&size), sizeof(size));
+    }
+
+    return {};
+}
+
+void bsd_mllp_server::accept_loop() {
+    while (!stop_requested_) {
+        struct sockaddr_in client_addr;
+#ifdef _WIN32
+        int client_addr_len = sizeof(client_addr);
+#else
+        socklen_t client_addr_len = sizeof(client_addr);
+#endif
+
+        socket_t client_socket =
+            accept(server_socket_,
+                   reinterpret_cast<struct sockaddr*>(&client_addr),
+                   &client_addr_len);
+
+        if (client_socket == INVALID_SOCKET_VALUE) {
+            if (stop_requested_) {
+                break;
+            }
+            // Accept failed, continue or break depending on error
+            continue;
+        }
+
+        // Configure client socket options
+        if (auto result = configure_socket_options(client_socket); !result) {
+            close_socket(client_socket);
+            continue;
+        }
+
+        // Extract client address info
+        char addr_str[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &client_addr.sin_addr, addr_str, sizeof(addr_str));
+        uint16_t client_port = ntohs(client_addr.sin_port);
+
+        // Create session
+        uint64_t session_id = generate_session_id();
+        auto session = std::make_unique<bsd_mllp_session>(
+            client_socket, session_id, std::string(addr_str), client_port);
+
+        // Increment active session count
+        ++active_sessions_;
+
+        // Notify callback
+        if (connection_callback_) {
+            connection_callback_(std::move(session));
+        }
+    }
+}
+
+uint64_t bsd_mllp_server::generate_session_id() {
+    return next_session_id_++;
+}
+
+}  // namespace pacs::bridge::mllp

--- a/src/mllp/bsd_mllp_server.h
+++ b/src/mllp/bsd_mllp_server.h
@@ -1,0 +1,200 @@
+#ifndef PACS_BRIDGE_MLLP_BSD_MLLP_SERVER_H
+#define PACS_BRIDGE_MLLP_BSD_MLLP_SERVER_H
+
+/**
+ * @file bsd_mllp_server.h
+ * @brief BSD socket implementation of MLLP network adapter
+ *
+ * Provides concrete implementations of mllp_session and mllp_server_adapter
+ * using Berkeley Socket API (BSD sockets / Winsock2).
+ *
+ * Platform support:
+ * - Windows: Winsock2
+ * - POSIX (Linux, macOS, BSD): BSD sockets
+ *
+ * This implementation does NOT include TLS support - that will be added
+ * in a separate implementation (tls_mllp_server).
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/305
+ */
+
+#include "pacs/bridge/mllp/mllp_network_adapter.h"
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+
+// Platform-specific socket types
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+using socket_t = SOCKET;
+constexpr socket_t INVALID_SOCKET_VALUE = INVALID_SOCKET;
+#else
+using socket_t = int;
+constexpr socket_t INVALID_SOCKET_VALUE = -1;
+#endif
+
+namespace pacs::bridge::mllp {
+
+// =============================================================================
+// BSD Socket Session Implementation
+// =============================================================================
+
+/**
+ * @brief BSD socket implementation of mllp_session
+ *
+ * Manages a single TCP connection using platform-specific socket API.
+ * Handles platform differences between Windows and POSIX systems.
+ */
+class bsd_mllp_session : public mllp_session {
+public:
+    /**
+     * @brief Constructor
+     *
+     * @param sock Connected socket
+     * @param session_id Unique identifier for this session
+     * @param remote_addr Remote peer address
+     * @param remote_port Remote peer port
+     */
+    bsd_mllp_session(socket_t sock, uint64_t session_id,
+                     std::string remote_addr, uint16_t remote_port);
+
+    ~bsd_mllp_session() override;
+
+    // Implement mllp_session interface
+    [[nodiscard]] std::expected<std::vector<uint8_t>, network_error>
+    receive(size_t max_bytes, std::chrono::milliseconds timeout) override;
+
+    [[nodiscard]] std::expected<size_t, network_error>
+    send(std::span<const uint8_t> data) override;
+
+    void close() override;
+
+    [[nodiscard]] bool is_open() const noexcept override;
+
+    [[nodiscard]] session_stats get_stats() const noexcept override;
+
+    [[nodiscard]] std::string remote_address() const noexcept override;
+
+    [[nodiscard]] uint16_t remote_port() const noexcept override;
+
+    [[nodiscard]] uint64_t session_id() const noexcept override;
+
+private:
+    /**
+     * @brief Set socket to non-blocking mode for timeout support
+     */
+    [[nodiscard]] std::expected<void, network_error> set_nonblocking(bool enable);
+
+    /**
+     * @brief Wait for socket to be readable/writable with timeout
+     *
+     * @param for_read true = wait for read, false = wait for write
+     * @param timeout Maximum wait time
+     * @return true if ready, false if timeout or error
+     */
+    [[nodiscard]] std::expected<bool, network_error>
+    wait_for_io(bool for_read, std::chrono::milliseconds timeout);
+
+    socket_t socket_;
+    uint64_t session_id_;
+    std::string remote_addr_;
+    uint16_t remote_port_;
+
+    // Statistics (thread-safe)
+    mutable std::mutex stats_mutex_;
+    session_stats stats_;
+
+    std::atomic<bool> is_open_{true};
+};
+
+// =============================================================================
+// BSD Socket Server Adapter Implementation
+// =============================================================================
+
+/**
+ * @brief BSD socket implementation of mllp_server_adapter
+ *
+ * Manages the server socket, accepts incoming connections, and creates
+ * bsd_mllp_session instances for each connection.
+ */
+class bsd_mllp_server : public mllp_server_adapter {
+public:
+    /**
+     * @brief Constructor
+     *
+     * @param config Server configuration
+     */
+    explicit bsd_mllp_server(const server_config& config);
+
+    ~bsd_mllp_server() override;
+
+    // Implement mllp_server_adapter interface
+    [[nodiscard]] std::expected<void, network_error> start() override;
+
+    void stop(bool wait_for_connections = true) override;
+
+    [[nodiscard]] bool is_running() const noexcept override;
+
+    [[nodiscard]] uint16_t port() const noexcept override;
+
+    void on_connection(on_connection_callback callback) override;
+
+    [[nodiscard]] size_t active_session_count() const noexcept override;
+
+private:
+    /**
+     * @brief Initialize platform-specific networking (Winsock on Windows)
+     */
+    [[nodiscard]] std::expected<void, network_error> initialize_networking();
+
+    /**
+     * @brief Cleanup platform-specific networking (Winsock on Windows)
+     */
+    void cleanup_networking();
+
+    /**
+     * @brief Create and configure the server socket
+     */
+    [[nodiscard]] std::expected<void, network_error> create_server_socket();
+
+    /**
+     * @brief Configure socket options (keep-alive, nodelay, etc.)
+     */
+    [[nodiscard]] std::expected<void, network_error>
+    configure_socket_options(socket_t sock);
+
+    /**
+     * @brief Accept loop - runs in background thread
+     */
+    void accept_loop();
+
+    /**
+     * @brief Generate unique session ID
+     */
+    uint64_t generate_session_id();
+
+    server_config config_;
+    socket_t server_socket_ = INVALID_SOCKET_VALUE;
+
+    std::atomic<bool> running_{false};
+    std::atomic<bool> stop_requested_{false};
+
+    std::thread accept_thread_;
+    on_connection_callback connection_callback_;
+
+    // Session tracking
+    std::atomic<size_t> active_sessions_{0};
+    std::atomic<uint64_t> next_session_id_{1};
+
+    mutable std::mutex state_mutex_;
+
+#ifdef _WIN32
+    bool winsock_initialized_ = false;
+#endif
+};
+
+}  // namespace pacs::bridge::mllp
+
+#endif  // PACS_BRIDGE_MLLP_BSD_MLLP_SERVER_H

--- a/src/mllp/mllp_network_adapter.cpp
+++ b/src/mllp/mllp_network_adapter.cpp
@@ -1,0 +1,17 @@
+/**
+ * @file mllp_network_adapter.cpp
+ * @brief Implementation of network adapter interfaces
+ *
+ * This file currently contains no implementation as the adapter interfaces
+ * are pure virtual. Concrete implementations are in bsd_mllp_server.cpp
+ * and future TLS-enabled implementations.
+ */
+
+#include "pacs/bridge/mllp/mllp_network_adapter.h"
+
+namespace pacs::bridge::mllp {
+
+// This file intentionally left empty.
+// All interface implementations are in concrete adapter classes.
+
+}  // namespace pacs::bridge::mllp


### PR DESCRIPTION
## Summary

Implements the foundation for abstracting MLLP server's network layer as specified in issue #305:

- Define abstract network adapter interfaces (`mllp_network_adapter.h`)
- Implement BSD socket-based server adapter (`bsd_mllp_server`)
- Support both Windows (Winsock2) and POSIX (Linux/macOS) platforms
- Enable future TLS support through adapter pattern

## Changes Made

### New Files

| File | Description |
|------|-------------|
| `include/pacs/bridge/mllp/mllp_network_adapter.h` | Abstract interface definitions |
| `src/mllp/mllp_network_adapter.cpp` | Interface implementation (empty) |
| `src/mllp/bsd_mllp_server.h` | BSD socket adapter declarations |
| `src/mllp/bsd_mllp_server.cpp` | BSD socket adapter implementation |

### Modified Files

- `CMakeLists.txt`: Added new source files to build configuration

### Key Components

1. **mllp_session** (abstract interface)
   - `receive()`: Receive data with timeout
   - `send()`: Send data
   - `close()`: Graceful shutdown
   - Session statistics and connection info

2. **mllp_server_adapter** (abstract interface)
   - `start()`: Begin listening for connections
   - `stop()`: Graceful server shutdown
   - `on_connection()`: Register connection callback

3. **bsd_mllp_session** (concrete implementation)
   - Platform-specific socket I/O (select/poll)
   - Send/receive with timeout support
   - Statistics tracking

4. **bsd_mllp_server** (concrete implementation)
   - Server socket creation and binding
   - Accept loop in background thread
   - Socket option configuration (keep-alive, nodelay, etc.)

## Platform Support

| Platform | Socket API | Keep-Alive Config |
|----------|-----------|-------------------|
| Windows | Winsock2 | SO_KEEPALIVE only |
| Linux | BSD sockets | TCP_KEEPIDLE/KEEPINTVL/KEEPCNT |
| macOS | BSD sockets | TCP_KEEPALIVE (no interval/count) |

## Test Plan

- [x] Code compiles on macOS (verified)
- [x] No build errors or warnings (except duplicate library warnings)
- [ ] Compile on Windows (requires CI)
- [ ] Compile on Linux (requires CI)
- [ ] Basic connection acceptance test (future PR)
- [ ] Multi-connection handling test (future PR)
- [ ] Send/receive data integrity test (future PR)

## Related Issues

Closes #305

Part of #277 (Parent epic: Create MLLP network adapter interface)

Blocks:
- Sub-issue 2: TLS support (to be created)
- Sub-issue 3: Testing and validation (to be created)

## Breaking Changes

None - This is new functionality that does not affect existing code.

## Rollback Plan

1. Revert this PR
2. Remove added files from CMakeLists.txt
3. No data migration needed (new files only)