### PR TITLE
test(integration): add system adapter integration tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1008,6 +1008,26 @@ else()
 endif()
 
 # =============================================================================
+# System Adapter Integration Tests (Issue #320, Phase 5b)
+# =============================================================================
+
+# System Integration Tests - Cross-adapter workflow tests
+# Requires SQLite for database adapter standalone mode
+if(PACS_BRIDGE_HAS_SQLITE)
+    add_integration_test(system_integration_test "integration;adapter;system;phase5b" 120)
+else()
+    message(STATUS "Skipping system_integration_test: requires SQLite (PACS_BRIDGE_HAS_SQLITE)")
+endif()
+
+# Standalone Mode Tests - Fallback adapter verification
+# Requires SQLite for database adapter standalone mode
+if(PACS_BRIDGE_HAS_SQLITE)
+    add_integration_test(standalone_mode_test "integration;adapter;standalone;phase5b" 120)
+else()
+    message(STATUS "Skipping standalone_mode_test: requires SQLite (PACS_BRIDGE_HAS_SQLITE)")
+endif()
+
+# =============================================================================
 # Test Summary
 # =============================================================================
 
@@ -1128,6 +1148,14 @@ message(STATUS "")
 message(STATUS "Phase 5 EMR Integration Tests:")
 message(STATUS "  - emr_e2e_test")
 message(STATUS "  - hapi_fhir_test")
+message(STATUS "")
+message(STATUS "Phase 5b System Adapter Integration Tests (Issue #320):")
+if(PACS_BRIDGE_HAS_SQLITE)
+    message(STATUS "  - system_integration_test (cross-adapter workflows)")
+    message(STATUS "  - standalone_mode_test (fallback adapter verification)")
+else()
+    message(STATUS "  (skipped - requires SQLite)")
+endif()
 message(STATUS "==========================")
 message(STATUS "")
 

--- a/tests/integration/standalone_mode_test.cpp
+++ b/tests/integration/standalone_mode_test.cpp
@@ -1,0 +1,508 @@
+/**
+ * @file standalone_mode_test.cpp
+ * @brief Integration tests verifying standalone (fallback) adapter operation
+ *
+ * Tests that all adapters function correctly in standalone mode, without
+ * any external system modules (database_system, network_system, etc.).
+ * This validates the fallback implementations:
+ *   - SQLite database adapter
+ *   - BSD socket MLLP adapter
+ *   - Memory-based PACS adapter
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/320
+ * @see https://github.com/kcenon/pacs_bridge/issues/287
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "test_utilities.h"
+
+#include "pacs/bridge/integration/database_adapter.h"
+#include "pacs/bridge/integration/pacs_adapter.h"
+#include "pacs/bridge/mllp/mllp_network_adapter.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pacs::bridge::integration {
+namespace {
+
+using namespace ::testing;
+using namespace pacs::bridge::integration::test;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// Database Adapter Standalone Tests
+// =============================================================================
+
+class StandaloneDatabaseTest : public Test {
+protected:
+    void SetUp() override {
+        db_ = create_test_database();
+        ASSERT_NE(db_->adapter, nullptr);
+    }
+
+    void TearDown() override {
+        db_.reset();
+    }
+
+    void create_test_table() {
+        auto result = db_->adapter->execute_schema(
+            "CREATE TABLE IF NOT EXISTS test_data ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  key TEXT NOT NULL UNIQUE,"
+            "  value TEXT,"
+            "  created_at INTEGER DEFAULT (strftime('%s','now'))"
+            ")"
+        );
+        ASSERT_TRUE(result.has_value()) << "Failed to create test table";
+    }
+
+    std::unique_ptr<test_database> db_;
+};
+
+TEST_F(StandaloneDatabaseTest, AdapterCreation) {
+    EXPECT_TRUE(db_->adapter->is_healthy());
+    EXPECT_GT(db_->adapter->available_connections(), 0u);
+    EXPECT_EQ(db_->adapter->active_connections(), 0u);
+}
+
+TEST_F(StandaloneDatabaseTest, SchemaExecution) {
+    create_test_table();
+    EXPECT_TRUE(db_->adapter->is_healthy());
+}
+
+TEST_F(StandaloneDatabaseTest, ConnectionAcquireRelease) {
+    auto conn_result = db_->adapter->acquire_connection();
+    ASSERT_TRUE(conn_result.has_value());
+
+    auto conn = std::move(conn_result.value());
+    EXPECT_TRUE(conn->is_valid());
+
+    db_->adapter->release_connection(std::move(conn));
+}
+
+TEST_F(StandaloneDatabaseTest, CrudOperations) {
+    create_test_table();
+
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    // INSERT
+    auto insert = conn.execute(
+        "INSERT INTO test_data (key, value) VALUES ('test_key', 'test_value')");
+    ASSERT_TRUE(insert.has_value());
+    EXPECT_EQ(conn.changes(), 1);
+
+    // SELECT
+    auto select = conn.execute("SELECT key, value FROM test_data WHERE key = 'test_key'");
+    ASSERT_TRUE(select.has_value());
+    ASSERT_TRUE(select.value()->next());
+    EXPECT_EQ(select.value()->current_row().get_string(0), "test_key");
+    EXPECT_EQ(select.value()->current_row().get_string(1), "test_value");
+
+    // UPDATE
+    auto update = conn.execute(
+        "UPDATE test_data SET value = 'updated' WHERE key = 'test_key'");
+    ASSERT_TRUE(update.has_value());
+    EXPECT_EQ(conn.changes(), 1);
+
+    // DELETE
+    auto del = conn.execute("DELETE FROM test_data WHERE key = 'test_key'");
+    ASSERT_TRUE(del.has_value());
+    EXPECT_EQ(conn.changes(), 1);
+
+    // Verify deletion
+    auto verify = conn.execute("SELECT COUNT(*) FROM test_data WHERE key = 'test_key'");
+    ASSERT_TRUE(verify.has_value());
+    ASSERT_TRUE(verify.value()->next());
+    EXPECT_EQ(verify.value()->current_row().get_int64(0), 0);
+}
+
+TEST_F(StandaloneDatabaseTest, PreparedStatements) {
+    create_test_table();
+
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    auto stmt = conn.prepare("INSERT INTO test_data (key, value) VALUES (?, ?)");
+    ASSERT_TRUE(stmt.has_value());
+    EXPECT_EQ(stmt.value()->parameter_count(), 2u);
+
+    auto bind1 = stmt.value()->bind_string(1, "prepared_key");
+    ASSERT_TRUE(bind1.has_value());
+    auto bind2 = stmt.value()->bind_string(2, "prepared_value");
+    ASSERT_TRUE(bind2.has_value());
+
+    auto exec = stmt.value()->execute();
+    ASSERT_TRUE(exec.has_value());
+}
+
+TEST_F(StandaloneDatabaseTest, TransactionCommit) {
+    create_test_table();
+
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    auto guard = transaction_guard::begin(conn);
+    ASSERT_TRUE(guard.has_value());
+
+    auto insert = conn.execute(
+        "INSERT INTO test_data (key, value) VALUES ('txn_key', 'txn_value')");
+    ASSERT_TRUE(insert.has_value());
+
+    auto commit = guard->commit();
+    ASSERT_TRUE(commit.has_value());
+
+    // Verify data persisted
+    auto select = conn.execute("SELECT value FROM test_data WHERE key = 'txn_key'");
+    ASSERT_TRUE(select.has_value());
+    ASSERT_TRUE(select.value()->next());
+    EXPECT_EQ(select.value()->current_row().get_string(0), "txn_value");
+}
+
+TEST_F(StandaloneDatabaseTest, TransactionRollback) {
+    create_test_table();
+
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    {
+        auto guard = transaction_guard::begin(conn);
+        ASSERT_TRUE(guard.has_value());
+
+        auto insert = conn.execute(
+            "INSERT INTO test_data (key, value) VALUES ('rollback_key', 'rollback_value')");
+        ASSERT_TRUE(insert.has_value());
+
+        // guard goes out of scope without commit -> auto rollback
+    }
+
+    // Verify data was rolled back
+    auto select = conn.execute("SELECT COUNT(*) FROM test_data WHERE key = 'rollback_key'");
+    ASSERT_TRUE(select.has_value());
+    ASSERT_TRUE(select.value()->next());
+    EXPECT_EQ(select.value()->current_row().get_int64(0), 0);
+}
+
+TEST_F(StandaloneDatabaseTest, ConnectionPoolExhaustion) {
+    // Create adapter with small pool
+    auto small_db = create_test_database(2);
+    ASSERT_NE(small_db->adapter, nullptr);
+
+    auto conn1 = small_db->adapter->acquire_connection();
+    ASSERT_TRUE(conn1.has_value());
+
+    auto conn2 = small_db->adapter->acquire_connection();
+    ASSERT_TRUE(conn2.has_value());
+
+    EXPECT_EQ(small_db->adapter->available_connections(), 0u);
+    EXPECT_EQ(small_db->adapter->active_connections(), 2u);
+
+    // Release one connection
+    small_db->adapter->release_connection(std::move(conn1.value()));
+    EXPECT_EQ(small_db->adapter->available_connections(), 1u);
+}
+
+// =============================================================================
+// PACS Adapter Standalone Tests
+// =============================================================================
+
+class StandalonePacsTest : public Test {
+protected:
+    void SetUp() override {
+        adapter_ = create_test_pacs_adapter();
+        ASSERT_NE(adapter_, nullptr);
+    }
+
+    void TearDown() override {
+        if (adapter_ && adapter_->is_connected()) {
+            adapter_->disconnect();
+        }
+        adapter_.reset();
+    }
+
+    std::shared_ptr<pacs_adapter> adapter_;
+};
+
+TEST_F(StandalonePacsTest, AdapterCreation) {
+    EXPECT_NE(adapter_, nullptr);
+}
+
+TEST_F(StandalonePacsTest, ConnectDisconnect) {
+    auto result = adapter_->connect();
+    EXPECT_TRUE(result.has_value());
+    EXPECT_TRUE(adapter_->is_connected());
+    EXPECT_TRUE(adapter_->is_healthy());
+
+    adapter_->disconnect();
+    EXPECT_FALSE(adapter_->is_connected());
+}
+
+TEST_F(StandalonePacsTest, MppsCreateValidRecord) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    auto mpps = adapter_->get_mpps_adapter();
+    ASSERT_NE(mpps, nullptr);
+
+    // Create valid MPPS record - stub accepts and validates
+    mpps_record record;
+    record.sop_instance_uid = "1.2.3.4.5.100";
+    record.scheduled_procedure_step_id = "SPS001";
+    record.performed_procedure_step_id = "PPS001";
+    record.performed_station_ae_title = "CT01";
+    record.performed_station_name = "CT Scanner";
+    record.performed_location = "Room 101";
+    record.start_datetime = std::chrono::system_clock::now();
+    record.status = "IN PROGRESS";
+    record.study_instance_uid = "1.2.3.4.5.200";
+    record.patient_id = "PAT001";
+    record.patient_name = "DOE^JOHN";
+
+    auto create_result = mpps->create_mpps(record);
+    EXPECT_TRUE(create_result.has_value());
+
+    // Stub get_mpps returns not_found (no-op storage)
+    auto get_result = mpps->get_mpps(record.sop_instance_uid);
+    EXPECT_FALSE(get_result.has_value());
+    EXPECT_EQ(get_result.error(), pacs_error::not_found);
+}
+
+TEST_F(StandalonePacsTest, MppsCreateInvalidRecord) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    auto mpps = adapter_->get_mpps_adapter();
+    ASSERT_NE(mpps, nullptr);
+
+    // Empty record should fail validation
+    mpps_record invalid_record;
+    auto result = mpps->create_mpps(invalid_record);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), pacs_error::validation_failed);
+}
+
+TEST_F(StandalonePacsTest, MppsQueryReturnsEmpty) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    auto mpps = adapter_->get_mpps_adapter();
+    ASSERT_NE(mpps, nullptr);
+
+    // Stub query returns empty result set
+    mpps_query_params params;
+    params.max_results = 10;
+    auto result = mpps->query_mpps(params);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result.value().empty());
+}
+
+TEST_F(StandalonePacsTest, MppsUpdateValidRecord) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    auto mpps = adapter_->get_mpps_adapter();
+    ASSERT_NE(mpps, nullptr);
+
+    // Create and update in stub mode - both should validate and succeed
+    mpps_record record;
+    record.sop_instance_uid = "1.2.3.4.5.101";
+    record.scheduled_procedure_step_id = "SPS002";
+    record.performed_procedure_step_id = "PPS002";
+    record.performed_station_ae_title = "MR01";
+    record.start_datetime = std::chrono::system_clock::now();
+    record.status = "IN PROGRESS";
+    record.study_instance_uid = "1.2.3.4.5.201";
+    record.patient_id = "PAT002";
+    record.patient_name = "SMITH^JANE";
+
+    EXPECT_TRUE(mpps->create_mpps(record).has_value());
+
+    // Update to COMPLETED (must include end_datetime for validation)
+    record.status = "COMPLETED";
+    record.end_datetime = std::chrono::system_clock::now();
+    auto update = mpps->update_mpps(record);
+    EXPECT_TRUE(update.has_value());
+}
+
+TEST_F(StandalonePacsTest, MwlQuery) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    auto mwl = adapter_->get_mwl_adapter();
+    ASSERT_NE(mwl, nullptr);
+
+    mwl_query_params params;
+    params.max_results = 10;
+    auto result = mwl->query_mwl(params);
+    EXPECT_TRUE(result.has_value());
+}
+
+TEST_F(StandalonePacsTest, StorageStubBehavior) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    auto storage = adapter_->get_storage_adapter();
+    ASSERT_NE(storage, nullptr);
+
+    // Store succeeds (validation only, no actual storage in stub)
+    dicom_dataset dataset;
+    dataset.sop_class_uid = "1.2.840.10008.5.1.4.1.1.2";
+    dataset.sop_instance_uid = "1.2.3.4.5.300";
+    dataset.set_string(0x00100020, "PAT003");
+    dataset.set_string(0x00100010, "WILSON^BOB");
+
+    auto store = storage->store(dataset);
+    EXPECT_TRUE(store.has_value());
+
+    // Stub always returns false for exists and not_found for retrieve
+    EXPECT_FALSE(storage->exists(dataset.sop_instance_uid));
+
+    auto retrieve = storage->retrieve(dataset.sop_instance_uid);
+    EXPECT_FALSE(retrieve.has_value());
+    EXPECT_EQ(retrieve.error(), pacs_error::not_found);
+}
+
+TEST_F(StandalonePacsTest, StorageInvalidDatasetRejected) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    auto storage = adapter_->get_storage_adapter();
+    ASSERT_NE(storage, nullptr);
+
+    // Empty SOP Instance UID should fail
+    dicom_dataset empty_dataset;
+    auto result = storage->store(empty_dataset);
+    EXPECT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), pacs_error::invalid_dataset);
+}
+
+TEST_F(StandalonePacsTest, SubAdaptersAvailable) {
+    auto connect = adapter_->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    EXPECT_NE(adapter_->get_mpps_adapter(), nullptr);
+    EXPECT_NE(adapter_->get_mwl_adapter(), nullptr);
+    EXPECT_NE(adapter_->get_storage_adapter(), nullptr);
+}
+
+// =============================================================================
+// MLLP Network Adapter Standalone Tests
+// =============================================================================
+
+class StandaloneMllpTest : public Test {
+protected:
+    void SetUp() override {
+        test_port_ = generate_test_port();
+    }
+
+    uint16_t test_port_;
+};
+
+TEST_F(StandaloneMllpTest, ServerConfigValidation) {
+    mllp::server_config config;
+    config.port = test_port_;
+    EXPECT_TRUE(config.is_valid());
+
+    mllp::server_config invalid_config;
+    invalid_config.port = 0;
+    EXPECT_FALSE(invalid_config.is_valid());
+}
+
+TEST_F(StandaloneMllpTest, ErrorCodeDescriptions) {
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::timeout)), "");
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::connection_closed)), "");
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::socket_error)), "");
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::bind_failed)), "");
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::tls_handshake_failed)), "");
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::invalid_config)), "");
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::would_block)), "");
+    EXPECT_NE(std::string(mllp::to_string(mllp::network_error::connection_refused)), "");
+}
+
+TEST_F(StandaloneMllpTest, SessionStatsDefaultValues) {
+    mllp::session_stats stats;
+    EXPECT_EQ(stats.bytes_received, 0u);
+    EXPECT_EQ(stats.bytes_sent, 0u);
+    EXPECT_EQ(stats.messages_received, 0u);
+    EXPECT_EQ(stats.messages_sent, 0u);
+}
+
+// =============================================================================
+// Cross-Adapter Resource Cleanup Tests
+// =============================================================================
+
+class StandaloneResourceCleanupTest : public Test {
+protected:
+    void SetUp() override {
+        db_ = create_test_database();
+        ASSERT_NE(db_->adapter, nullptr);
+
+        pacs_ = create_test_pacs_adapter();
+        ASSERT_NE(pacs_, nullptr);
+    }
+
+    void TearDown() override {
+        if (pacs_ && pacs_->is_connected()) {
+            pacs_->disconnect();
+        }
+        pacs_.reset();
+        db_.reset();
+    }
+
+    std::unique_ptr<test_database> db_;
+    std::shared_ptr<pacs_adapter> pacs_;
+};
+
+TEST_F(StandaloneResourceCleanupTest, DatabaseCleanShutdown) {
+    // Acquire and use connections
+    auto conn1 = db_->adapter->acquire_connection();
+    ASSERT_TRUE(conn1.has_value());
+
+    auto conn2 = db_->adapter->acquire_connection();
+    ASSERT_TRUE(conn2.has_value());
+
+    // Release connections
+    db_->adapter->release_connection(std::move(conn1.value()));
+    db_->adapter->release_connection(std::move(conn2.value()));
+
+    // Adapter should be healthy after releasing all connections
+    EXPECT_TRUE(db_->adapter->is_healthy());
+    EXPECT_EQ(db_->adapter->active_connections(), 0u);
+}
+
+TEST_F(StandaloneResourceCleanupTest, PacsCleanShutdown) {
+    auto connect = pacs_->connect();
+    ASSERT_TRUE(connect.has_value());
+    EXPECT_TRUE(pacs_->is_connected());
+
+    pacs_->disconnect();
+    EXPECT_FALSE(pacs_->is_connected());
+}
+
+TEST_F(StandaloneResourceCleanupTest, MultipleAdapterLifecycles) {
+    // Create and destroy adapters multiple times to check for resource leaks
+    for (int i = 0; i < 3; ++i) {
+        auto temp_db = create_test_database();
+        ASSERT_NE(temp_db->adapter, nullptr);
+        EXPECT_TRUE(temp_db->adapter->is_healthy());
+
+        auto temp_pacs = create_test_pacs_adapter();
+        ASSERT_NE(temp_pacs, nullptr);
+        auto connect = temp_pacs->connect();
+        EXPECT_TRUE(connect.has_value());
+        temp_pacs->disconnect();
+    }
+}
+
+}  // namespace
+}  // namespace pacs::bridge::integration

--- a/tests/integration/system_integration_test.cpp
+++ b/tests/integration/system_integration_test.cpp
@@ -1,0 +1,571 @@
+/**
+ * @file system_integration_test.cpp
+ * @brief Integration tests verifying adapters work with system modules
+ *
+ * Tests adapter combinations and cross-adapter workflows. When system
+ * modules (database_system, network_system, etc.) are available, tests
+ * verify the integrated implementations. Otherwise, tests validate the
+ * standalone fallback implementations working together.
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/320
+ * @see https://github.com/kcenon/pacs_bridge/issues/287
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "test_utilities.h"
+
+#include "pacs/bridge/integration/database_adapter.h"
+#include "pacs/bridge/integration/pacs_adapter.h"
+#include "pacs/bridge/mllp/mllp_network_adapter.h"
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pacs::bridge::integration {
+namespace {
+
+using namespace ::testing;
+using namespace pacs::bridge::integration::test;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// Database + PACS Combined Workflow Tests
+// =============================================================================
+
+class DatabasePacsIntegrationTest : public Test {
+protected:
+    void SetUp() override {
+        db_ = create_test_database();
+        ASSERT_NE(db_->adapter, nullptr);
+
+        pacs_ = create_test_pacs_adapter();
+        ASSERT_NE(pacs_, nullptr);
+
+        auto connect = pacs_->connect();
+        ASSERT_TRUE(connect.has_value());
+
+        // Create schema for storing MPPS tracking data
+        auto schema = db_->adapter->execute_schema(
+            "CREATE TABLE IF NOT EXISTS mpps_tracking ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  sop_instance_uid TEXT NOT NULL UNIQUE,"
+            "  patient_id TEXT NOT NULL,"
+            "  status TEXT NOT NULL DEFAULT 'IN PROGRESS',"
+            "  created_at INTEGER DEFAULT (strftime('%s','now')),"
+            "  updated_at INTEGER DEFAULT (strftime('%s','now'))"
+            ")"
+        );
+        ASSERT_TRUE(schema.has_value());
+    }
+
+    void TearDown() override {
+        if (pacs_ && pacs_->is_connected()) {
+            pacs_->disconnect();
+        }
+        pacs_.reset();
+        db_.reset();
+    }
+
+    std::unique_ptr<test_database> db_;
+    std::shared_ptr<pacs_adapter> pacs_;
+};
+
+TEST_F(DatabasePacsIntegrationTest, MppsCreateWithDatabaseTracking) {
+    auto mpps = pacs_->get_mpps_adapter();
+    ASSERT_NE(mpps, nullptr);
+
+    // Create MPPS record through PACS adapter
+    mpps_record record;
+    record.sop_instance_uid = "1.2.3.4.5.500";
+    record.scheduled_procedure_step_id = "SPS100";
+    record.performed_procedure_step_id = "PPS100";
+    record.performed_station_ae_title = "CT01";
+    record.start_datetime = std::chrono::system_clock::now();
+    record.status = "IN PROGRESS";
+    record.study_instance_uid = "1.2.3.4.5.600";
+    record.patient_id = "PAT100";
+    record.patient_name = "ADAMS^ALICE";
+
+    auto pacs_result = mpps->create_mpps(record);
+    ASSERT_TRUE(pacs_result.has_value());
+
+    // Track in database
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    auto stmt = conn.prepare(
+        "INSERT INTO mpps_tracking (sop_instance_uid, patient_id, status) VALUES (?, ?, ?)");
+    ASSERT_TRUE(stmt.has_value());
+    ASSERT_TRUE(stmt.value()->bind_string(1, record.sop_instance_uid).has_value());
+    ASSERT_TRUE(stmt.value()->bind_string(2, record.patient_id).has_value());
+    ASSERT_TRUE(stmt.value()->bind_string(3, record.status).has_value());
+    auto exec = stmt.value()->execute();
+    ASSERT_TRUE(exec.has_value());
+
+    // Verify tracking data
+    auto select = conn.execute(
+        "SELECT status FROM mpps_tracking WHERE sop_instance_uid = '1.2.3.4.5.500'");
+    ASSERT_TRUE(select.has_value());
+    ASSERT_TRUE(select.value()->next());
+    EXPECT_EQ(select.value()->current_row().get_string(0), "IN PROGRESS");
+}
+
+TEST_F(DatabasePacsIntegrationTest, MppsUpdateWithDatabaseSync) {
+    auto mpps = pacs_->get_mpps_adapter();
+    ASSERT_NE(mpps, nullptr);
+
+    // Create MPPS
+    mpps_record record;
+    record.sop_instance_uid = "1.2.3.4.5.501";
+    record.scheduled_procedure_step_id = "SPS101";
+    record.performed_procedure_step_id = "PPS101";
+    record.performed_station_ae_title = "MR01";
+    record.start_datetime = std::chrono::system_clock::now();
+    record.status = "IN PROGRESS";
+    record.study_instance_uid = "1.2.3.4.5.601";
+    record.patient_id = "PAT101";
+    record.patient_name = "BAKER^BOB";
+
+    ASSERT_TRUE(mpps->create_mpps(record).has_value());
+
+    // Track in database
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    auto track = conn.execute(
+        "INSERT INTO mpps_tracking (sop_instance_uid, patient_id, status) "
+        "VALUES ('1.2.3.4.5.501', 'PAT101', 'IN PROGRESS')");
+    ASSERT_TRUE(track.has_value());
+
+    // Update MPPS to completed
+    record.status = "COMPLETED";
+    record.end_datetime = std::chrono::system_clock::now();
+    ASSERT_TRUE(mpps->update_mpps(record).has_value());
+
+    // Sync status to database
+    auto update = conn.execute(
+        "UPDATE mpps_tracking SET status = 'COMPLETED', "
+        "updated_at = strftime('%s','now') "
+        "WHERE sop_instance_uid = '1.2.3.4.5.501'");
+    ASSERT_TRUE(update.has_value());
+    EXPECT_EQ(conn.changes(), 1);
+
+    // PACS stub doesn't persist, so get_mpps returns not_found
+    auto pacs_record = mpps->get_mpps("1.2.3.4.5.501");
+    EXPECT_FALSE(pacs_record.has_value());
+
+    // Database is the authoritative source in standalone mode
+    auto db_record = conn.execute(
+        "SELECT status FROM mpps_tracking WHERE sop_instance_uid = '1.2.3.4.5.501'");
+    ASSERT_TRUE(db_record.has_value());
+    ASSERT_TRUE(db_record.value()->next());
+    EXPECT_EQ(db_record.value()->current_row().get_string(0), "COMPLETED");
+}
+
+TEST_F(DatabasePacsIntegrationTest, StorageWithDatabaseIndex) {
+    auto storage = pacs_->get_storage_adapter();
+    ASSERT_NE(storage, nullptr);
+
+    // Create index table
+    auto schema = db_->adapter->execute_schema(
+        "CREATE TABLE IF NOT EXISTS dicom_index ("
+        "  sop_instance_uid TEXT PRIMARY KEY,"
+        "  patient_id TEXT,"
+        "  sop_class_uid TEXT"
+        ")"
+    );
+    ASSERT_TRUE(schema.has_value());
+
+    // Store DICOM dataset (stub accepts but doesn't persist)
+    dicom_dataset dataset;
+    dataset.sop_class_uid = "1.2.840.10008.5.1.4.1.1.2";
+    dataset.sop_instance_uid = "1.2.3.4.5.700";
+    dataset.set_string(0x00100020, "PAT200");
+
+    auto store = storage->store(dataset);
+    ASSERT_TRUE(store.has_value());
+
+    // Index in database - database does persist
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    auto stmt = conn.prepare(
+        "INSERT INTO dicom_index (sop_instance_uid, patient_id, sop_class_uid) "
+        "VALUES (?, ?, ?)");
+    ASSERT_TRUE(stmt.has_value());
+    ASSERT_TRUE(stmt.value()->bind_string(1, dataset.sop_instance_uid).has_value());
+    ASSERT_TRUE(stmt.value()->bind_string(2, "PAT200").has_value());
+    ASSERT_TRUE(stmt.value()->bind_string(3, dataset.sop_class_uid).has_value());
+    ASSERT_TRUE(stmt.value()->execute().has_value());
+
+    // Query from database index - database lookup works
+    auto select = conn.execute(
+        "SELECT sop_instance_uid FROM dicom_index WHERE patient_id = 'PAT200'");
+    ASSERT_TRUE(select.has_value());
+    ASSERT_TRUE(select.value()->next());
+
+    auto uid = select.value()->current_row().get_string(0);
+    EXPECT_EQ(uid, "1.2.3.4.5.700");
+
+    // Note: PACS storage stub doesn't persist, so exists/retrieve won't work.
+    // The database index is the authoritative source in standalone mode.
+    EXPECT_FALSE(storage->exists(uid));
+}
+
+// =============================================================================
+// Concurrent Adapter Usage Tests
+// =============================================================================
+
+class ConcurrentAdapterTest : public Test {
+protected:
+    void SetUp() override {
+        db_ = create_test_database(5);
+        ASSERT_NE(db_->adapter, nullptr);
+
+        auto schema = db_->adapter->execute_schema(
+            "CREATE TABLE IF NOT EXISTS concurrent_test ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  thread_id INTEGER NOT NULL,"
+            "  value TEXT NOT NULL"
+            ")"
+        );
+        ASSERT_TRUE(schema.has_value());
+    }
+
+    void TearDown() override {
+        db_.reset();
+    }
+
+    std::unique_ptr<test_database> db_;
+};
+
+TEST_F(ConcurrentAdapterTest, ConcurrentDatabaseWrites) {
+    constexpr int num_threads = 4;
+    constexpr int inserts_per_thread = 10;
+    std::vector<std::future<bool>> futures;
+
+    for (int t = 0; t < num_threads; ++t) {
+        futures.push_back(std::async(std::launch::async, [this, t]() -> bool {
+            for (int i = 0; i < inserts_per_thread; ++i) {
+                auto scope = connection_scope::acquire(*db_->adapter);
+                if (!scope.has_value()) {
+                    return false;
+                }
+                auto& conn = scope->connection();
+
+                auto stmt = conn.prepare(
+                    "INSERT INTO concurrent_test (thread_id, value) VALUES (?, ?)");
+                if (!stmt.has_value()) {
+                    return false;
+                }
+                if (!stmt.value()->bind_int64(1, t).has_value()) {
+                    return false;
+                }
+                auto val = "thread_" + std::to_string(t) + "_item_" + std::to_string(i);
+                if (!stmt.value()->bind_string(2, val).has_value()) {
+                    return false;
+                }
+                if (!stmt.value()->execute().has_value()) {
+                    return false;
+                }
+            }
+            return true;
+        }));
+    }
+
+    // Wait for all threads
+    for (auto& f : futures) {
+        EXPECT_TRUE(f.get());
+    }
+
+    // Verify total count
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    auto count = conn.execute("SELECT COUNT(*) FROM concurrent_test");
+    ASSERT_TRUE(count.has_value());
+    ASSERT_TRUE(count.value()->next());
+    EXPECT_EQ(count.value()->current_row().get_int64(0),
+              num_threads * inserts_per_thread);
+}
+
+TEST_F(ConcurrentAdapterTest, ConcurrentDatabaseReads) {
+    // Insert test data
+    auto scope = connection_scope::acquire(*db_->adapter);
+    ASSERT_TRUE(scope.has_value());
+    auto& conn = scope->connection();
+
+    for (int i = 0; i < 20; ++i) {
+        auto sql = "INSERT INTO concurrent_test (thread_id, value) VALUES (" +
+                   std::to_string(i % 4) + ", 'value_" + std::to_string(i) + "')";
+        ASSERT_TRUE(conn.execute(sql).has_value());
+    }
+
+    // Concurrent reads
+    constexpr int num_readers = 4;
+    std::vector<std::future<int64_t>> futures;
+
+    for (int t = 0; t < num_readers; ++t) {
+        futures.push_back(std::async(std::launch::async, [this, t]() -> int64_t {
+            auto read_scope = connection_scope::acquire(*db_->adapter);
+            if (!read_scope.has_value()) {
+                return -1;
+            }
+            auto& read_conn = read_scope->connection();
+
+            auto result = read_conn.execute(
+                "SELECT COUNT(*) FROM concurrent_test WHERE thread_id = " +
+                std::to_string(t));
+            if (!result.has_value() || !result.value()->next()) {
+                return -1;
+            }
+            return result.value()->current_row().get_int64(0);
+        }));
+    }
+
+    int64_t total = 0;
+    for (auto& f : futures) {
+        auto count = f.get();
+        EXPECT_GE(count, 0);
+        total += count;
+    }
+    EXPECT_EQ(total, 20);
+}
+
+// =============================================================================
+// Adapter Lifecycle Management Tests
+// =============================================================================
+
+class AdapterLifecycleTest : public Test {};
+
+TEST_F(AdapterLifecycleTest, DatabaseAdapterRecreation) {
+    // Create, use, destroy, and recreate to verify no state leakage
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        auto db = create_test_database();
+        ASSERT_NE(db->adapter, nullptr);
+        EXPECT_TRUE(db->adapter->is_healthy());
+
+        auto schema = db->adapter->execute_schema(
+            "CREATE TABLE IF NOT EXISTS lifecycle_test (id INTEGER PRIMARY KEY, data TEXT)");
+        ASSERT_TRUE(schema.has_value());
+
+        auto scope = connection_scope::acquire(*db->adapter);
+        ASSERT_TRUE(scope.has_value());
+
+        auto insert = scope->connection().execute(
+            "INSERT INTO lifecycle_test (data) VALUES ('cycle_" +
+            std::to_string(cycle) + "')");
+        ASSERT_TRUE(insert.has_value());
+    }
+}
+
+TEST_F(AdapterLifecycleTest, PacsAdapterReconnection) {
+    auto pacs = create_test_pacs_adapter();
+    ASSERT_NE(pacs, nullptr);
+
+    // Connect -> disconnect -> reconnect cycle
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        auto connect = pacs->connect();
+        ASSERT_TRUE(connect.has_value());
+        EXPECT_TRUE(pacs->is_connected());
+
+        // Perform operation
+        auto mpps = pacs->get_mpps_adapter();
+        ASSERT_NE(mpps, nullptr);
+
+        mpps_query_params params;
+        params.max_results = 5;
+        auto query = mpps->query_mpps(params);
+        EXPECT_TRUE(query.has_value());
+
+        pacs->disconnect();
+        EXPECT_FALSE(pacs->is_connected());
+    }
+}
+
+TEST_F(AdapterLifecycleTest, AllAdaptersCombinedLifecycle) {
+    // Create all adapters
+    auto db = create_test_database();
+    ASSERT_NE(db->adapter, nullptr);
+
+    auto pacs = create_test_pacs_adapter();
+    ASSERT_NE(pacs, nullptr);
+
+    // Initialize all
+    auto schema = db->adapter->execute_schema(
+        "CREATE TABLE IF NOT EXISTS combined_test (id INTEGER PRIMARY KEY)");
+    ASSERT_TRUE(schema.has_value());
+
+    auto connect = pacs->connect();
+    ASSERT_TRUE(connect.has_value());
+
+    // Use all adapters
+    auto db_scope = connection_scope::acquire(*db->adapter);
+    ASSERT_TRUE(db_scope.has_value());
+    ASSERT_TRUE(db_scope->connection().execute(
+        "INSERT INTO combined_test (id) VALUES (1)").has_value());
+
+    auto mpps = pacs->get_mpps_adapter();
+    ASSERT_NE(mpps, nullptr);
+
+    // Shutdown in reverse order
+    pacs->disconnect();
+    EXPECT_FALSE(pacs->is_connected());
+
+    // Database cleanup happens automatically via RAII
+}
+
+// =============================================================================
+// Error Scenario Tests
+// =============================================================================
+
+class AdapterErrorTest : public Test {};
+
+TEST_F(AdapterErrorTest, DatabaseInvalidPath) {
+    database_config config;
+    config.database_path = "/nonexistent/directory/test.db";
+    config.pool_size = 1;
+
+    // Factory should still return an adapter (may fail on first use)
+    auto adapter = create_database_adapter(config);
+    // The adapter may or may not be null depending on implementation
+    // If it's not null, operations should fail gracefully
+    if (adapter) {
+        auto conn = adapter->acquire_connection();
+        // Connection may fail on invalid path
+        if (conn.has_value()) {
+            auto result = conn.value()->execute("SELECT 1");
+            // May or may not succeed depending on how error is handled
+        }
+    }
+}
+
+TEST_F(AdapterErrorTest, PacsOperationsWithoutConnect) {
+    auto pacs = create_test_pacs_adapter();
+    ASSERT_NE(pacs, nullptr);
+    EXPECT_FALSE(pacs->is_connected());
+
+    // Operations before connect should handle gracefully
+    auto mpps = pacs->get_mpps_adapter();
+    // Sub-adapters should still be accessible even before connect
+    EXPECT_NE(mpps, nullptr);
+}
+
+TEST_F(AdapterErrorTest, DicomDatasetValidation) {
+    dicom_dataset dataset;
+    EXPECT_TRUE(dataset.attributes.empty());
+    EXPECT_EQ(dataset.sop_class_uid, "");
+    EXPECT_EQ(dataset.sop_instance_uid, "");
+
+    dataset.set_string(0x00100020, "PAT_TEST");
+    EXPECT_TRUE(dataset.has_tag(0x00100020));
+
+    auto value = dataset.get_string(0x00100020);
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(value.value(), "PAT_TEST");
+
+    dataset.remove_tag(0x00100020);
+    EXPECT_FALSE(dataset.has_tag(0x00100020));
+
+    auto missing = dataset.get_string(0x00100020);
+    EXPECT_FALSE(missing.has_value());
+}
+
+TEST_F(AdapterErrorTest, MppsRecordValidation) {
+    mpps_record record;
+    // Empty record should not be valid
+    EXPECT_FALSE(record.is_valid());
+
+    // Fill all required fields (sop_instance_uid, scheduled/performed_procedure_step_id, status)
+    record.sop_instance_uid = "1.2.3.4.5";
+    record.scheduled_procedure_step_id = "SPS001";
+    record.performed_procedure_step_id = "PPS001";
+    record.status = "IN PROGRESS";
+    record.patient_id = "PAT001";
+    record.start_datetime = std::chrono::system_clock::now();
+    EXPECT_TRUE(record.is_valid());
+}
+
+TEST_F(AdapterErrorTest, MwlItemValidation) {
+    mwl_item item;
+    EXPECT_FALSE(item.is_valid());
+
+    // All required fields: accession_number, scheduled_procedure_step_id,
+    // patient_id, patient_name, modality
+    item.accession_number = "ACC001";
+    item.scheduled_procedure_step_id = "SPS001";
+    item.patient_id = "PAT001";
+    item.patient_name = "DOE^JOHN";
+    item.modality = "CT";
+    item.scheduled_datetime = std::chrono::system_clock::now();
+    EXPECT_TRUE(item.is_valid());
+}
+
+// =============================================================================
+// Conditional System Integration Tests
+// =============================================================================
+
+#ifdef PACS_BRIDGE_HAS_DATABASE_SYSTEM
+
+class DatabaseSystemIntegrationTest : public Test {
+protected:
+    void SetUp() override {
+        // When database_system is available, the factory function
+        // may use database_pool_adapter instead of sqlite_database_adapter
+        db_ = create_test_database();
+        ASSERT_NE(db_->adapter, nullptr);
+    }
+
+    void TearDown() override {
+        db_.reset();
+    }
+
+    std::unique_ptr<test_database> db_;
+};
+
+TEST_F(DatabaseSystemIntegrationTest, PooledConnectionBehavior) {
+    EXPECT_TRUE(db_->adapter->is_healthy());
+    EXPECT_GT(db_->adapter->available_connections(), 0u);
+}
+
+#endif  // PACS_BRIDGE_HAS_DATABASE_SYSTEM
+
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+
+class PacsSystemIntegrationTest : public Test {
+protected:
+    void SetUp() override {
+        pacs_ = create_test_pacs_adapter();
+        ASSERT_NE(pacs_, nullptr);
+    }
+
+    void TearDown() override {
+        if (pacs_ && pacs_->is_connected()) {
+            pacs_->disconnect();
+        }
+        pacs_.reset();
+    }
+
+    std::shared_ptr<pacs_adapter> pacs_;
+};
+
+TEST_F(PacsSystemIntegrationTest, SystemBackedOperations) {
+    auto connect = pacs_->connect();
+    EXPECT_TRUE(connect.has_value());
+    EXPECT_TRUE(pacs_->is_healthy());
+}
+
+#endif  // PACS_BRIDGE_HAS_PACS_SYSTEM
+
+}  // namespace
+}  // namespace pacs::bridge::integration

--- a/tests/integration/test_utilities.h
+++ b/tests/integration/test_utilities.h
@@ -1,0 +1,175 @@
+/**
+ * @file test_utilities.h
+ * @brief Common utilities for system adapter integration tests
+ *
+ * Provides helper functions, fixtures, and utilities for testing adapter
+ * integration across different build modes (standalone vs integrated).
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/320
+ */
+
+#ifndef PACS_BRIDGE_TESTS_INTEGRATION_TEST_UTILITIES_H
+#define PACS_BRIDGE_TESTS_INTEGRATION_TEST_UTILITIES_H
+
+#include "test_helpers.h"
+
+#include "pacs/bridge/integration/database_adapter.h"
+#include "pacs/bridge/integration/pacs_adapter.h"
+#include "pacs/bridge/mllp/mllp_network_adapter.h"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <string>
+#include <thread>
+
+namespace pacs::bridge::integration::test {
+
+// =============================================================================
+// Port Generation
+// =============================================================================
+
+/**
+ * @brief Generate unique port number for test isolation
+ *
+ * Uses a shared atomic counter to avoid port collisions between tests
+ * running in the same process.
+ */
+inline uint16_t generate_test_port() {
+    static std::atomic<uint16_t> port_counter{16000};
+    return port_counter.fetch_add(1);
+}
+
+// =============================================================================
+// Temporary File Management
+// =============================================================================
+
+/**
+ * @brief Generate a unique temporary database path for testing
+ */
+inline std::filesystem::path generate_temp_db_path(const std::string& prefix = "integration_test") {
+    static std::atomic<int> counter{0};
+    auto temp_dir = std::filesystem::temp_directory_path();
+    auto timestamp = std::chrono::system_clock::now().time_since_epoch().count();
+    return temp_dir / (prefix + "_" + std::to_string(timestamp) + "_" +
+                       std::to_string(counter.fetch_add(1)) + ".db");
+}
+
+/**
+ * @brief RAII guard for temporary files
+ *
+ * Automatically removes the file when the guard goes out of scope.
+ */
+class temp_file_guard {
+public:
+    explicit temp_file_guard(std::filesystem::path path)
+        : path_(std::move(path)) {}
+
+    ~temp_file_guard() {
+        std::error_code ec;
+        std::filesystem::remove(path_, ec);
+    }
+
+    temp_file_guard(const temp_file_guard&) = delete;
+    temp_file_guard& operator=(const temp_file_guard&) = delete;
+
+    [[nodiscard]] const std::filesystem::path& path() const { return path_; }
+    [[nodiscard]] std::string string() const { return path_.string(); }
+
+private:
+    std::filesystem::path path_;
+};
+
+// =============================================================================
+// Adapter Factory Helpers
+// =============================================================================
+
+/**
+ * @brief Create a database adapter configured for testing
+ *
+ * Creates a SQLite adapter with a temporary database file.
+ * Returns both the adapter and a path guard for cleanup.
+ */
+struct test_database {
+    std::shared_ptr<database_adapter> adapter;
+    std::filesystem::path db_path;
+
+    ~test_database() {
+        adapter.reset();
+        std::error_code ec;
+        std::filesystem::remove(db_path, ec);
+    }
+};
+
+inline std::unique_ptr<test_database> create_test_database(
+    std::size_t pool_size = 3) {
+    auto result = std::make_unique<test_database>();
+    result->db_path = generate_temp_db_path();
+
+    database_config config;
+    config.database_path = result->db_path.string();
+    config.pool_size = pool_size;
+    config.connection_timeout = std::chrono::seconds{5};
+    config.query_timeout = std::chrono::seconds{10};
+    config.enable_wal = true;
+    config.busy_timeout_ms = 3000;
+
+    result->adapter = create_database_adapter(config);
+    return result;
+}
+
+/**
+ * @brief Create a PACS adapter configured for testing (standalone mode)
+ */
+inline std::shared_ptr<pacs_adapter> create_test_pacs_adapter() {
+    pacs_config config;
+    config.server_ae_title = "TEST_PACS";
+    config.server_hostname = "localhost";
+    config.server_port = 11112;
+    config.calling_ae_title = "TEST_BRIDGE";
+    config.connection_timeout = std::chrono::seconds{5};
+    config.query_timeout = std::chrono::seconds{10};
+
+    return create_pacs_adapter(config);
+}
+
+/**
+ * @brief Create an MLLP server config for testing
+ */
+inline mllp::server_config create_test_server_config(uint16_t port = 0) {
+    mllp::server_config config;
+    config.port = port > 0 ? port : generate_test_port();
+    config.backlog = 5;
+    config.reuse_addr = true;
+    config.no_delay = true;
+    config.keep_alive = false;
+    return config;
+}
+
+// =============================================================================
+// Wait Utilities
+// =============================================================================
+
+/**
+ * @brief Wait for a condition with timeout using sleep-based polling
+ *
+ * More appropriate for integration tests where responsiveness is less
+ * critical than CPU efficiency.
+ */
+template <typename Predicate>
+bool wait_for_condition(Predicate pred,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds{5000},
+                        std::chrono::milliseconds interval = std::chrono::milliseconds{10}) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!pred()) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return false;
+        }
+        std::this_thread::sleep_for(interval);
+    }
+    return true;
+}
+
+}  // namespace pacs::bridge::integration::test
+
+#endif  // PACS_BRIDGE_TESTS_INTEGRATION_TEST_UTILITIES_H


### PR DESCRIPTION
Closes #320

## Summary
- Add integration tests verifying system adapters work correctly in standalone and integrated modes
- Create `test_utilities.h` with common helpers for adapter test setup (port generation, temp DB management, factory helpers)
- Create `standalone_mode_test.cpp` with 24 tests for fallback adapter verification (SQLite, BSD MLLP, memory PACS)
- Create `system_integration_test.cpp` with 13 tests for cross-adapter workflows and concurrent access

## Test Coverage
| Category | Tests | Description |
|----------|-------|-------------|
| Database Standalone | 8 | CRUD, transactions, connection pooling, pool exhaustion |
| PACS Standalone | 10 | Stub validation, MPPS/MWL/Storage operations, error handling |
| MLLP Standalone | 3 | Config validation, error codes, session stats |
| Resource Cleanup | 3 | Multi-adapter lifecycle, clean shutdown |
| DB+PACS Combined | 3 | MPPS tracking, status sync, storage indexing |
| Concurrent Access | 2 | Multi-threaded writes and reads |
| Adapter Lifecycle | 3 | Recreation, reconnection, combined lifecycle |
| Error Scenarios | 5 | Invalid paths, disconnected ops, data validation |

## Test Plan
- [x] All 37 tests pass locally (24 standalone + 13 system)
- [x] Build succeeds with no warnings
- [x] Tests require SQLite (conditional via PACS_BRIDGE_HAS_SQLITE)
- [x] Conditional compilation blocks for PACS_BRIDGE_HAS_DATABASE_SYSTEM and PACS_BRIDGE_HAS_PACS_SYSTEM
- [ ] CI passes on Ubuntu and macOS