### PR TITLE
refactor(router): migrate queue_manager from std::thread to thread_adapter (#282)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ if(NOT BRIDGE_STANDALONE_BUILD)
         src/integration/executor_adapter.cpp
         src/integration/logger_adapter.cpp
         src/integration/network_adapter.cpp
-        src/integration/thread_adapter.cpp
     )
     list(APPEND PACS_BRIDGE_HEADERS
         include/pacs/bridge/integration/executor_adapter.h
@@ -182,6 +181,11 @@ if(PACS_BRIDGE_HAS_SQLITE)
         src/integration/database_adapter.cpp
     )
 endif()
+
+# Thread adapter (always available - simple_thread_adapter fallback for standalone)
+list(APPEND PACS_BRIDGE_SOURCES
+    src/integration/thread_adapter.cpp
+)
 
 # MWL adapter - abstraction for MWL storage
 # See: https://github.com/kcenon/pacs_bridge/issues/285

--- a/src/integration/thread_adapter.cpp
+++ b/src/integration/thread_adapter.cpp
@@ -13,7 +13,9 @@
 
 #include "pacs/bridge/integration/thread_adapter.h"
 
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
 #include <kcenon/thread/thread_pool.h>
+#endif
 
 #include <algorithm>
 #include <atomic>
@@ -24,6 +26,8 @@
 #include <vector>
 
 namespace pacs::bridge::integration {
+
+#ifndef PACS_BRIDGE_STANDALONE_BUILD
 
 // =============================================================================
 // thread_pool_adapter - Wraps thread_system's thread_pool
@@ -110,6 +114,8 @@ private:
     std::atomic<bool> running_{false};
     mutable std::mutex mutex_;
 };
+
+#endif  // PACS_BRIDGE_STANDALONE_BUILD
 
 // =============================================================================
 // simple_thread_adapter - Standalone Fallback


### PR DESCRIPTION
## Summary
- Replace raw `std::thread` worker/cleanup threads in `queue_manager` with `thread_adapter` for centralized thread management and priority scheduling (Phase 3a #280 follow-up)
- Guard `thread_pool_adapter` with `#ifndef PACS_BRIDGE_STANDALONE_BUILD` and move `thread_adapter.cpp` to always-compiled sources so `simple_thread_adapter` is available in standalone builds
- Unify `worker_futures_`/`cleanup_future_` outside `#ifndef` guards, eliminating duplicated shutdown logic between IExecutor and standalone code paths
- Fix pre-existing `NackMaxRetries` test failure caused by retry delay (1s) vs sleep duration (10ms) mismatch

## Changes

| File | Change |
|------|--------|
| `src/integration/thread_adapter.cpp` | Guard `thread_pool_adapter` and `#include <kcenon/thread/thread_pool.h>` with `#ifndef PACS_BRIDGE_STANDALONE_BUILD` |
| `CMakeLists.txt` | Move `thread_adapter.cpp` from conditional block to always-compiled sources |
| `src/router/queue_manager.cpp` | Replace `std::thread`/`cleanup_thread_` with `thread_adapter` pool; unify future tracking |
| `tests/queue_manager_test.cpp` | Add `WorkerThreadTest` suite (3 tests); fix `NackMaxRetries` |

## Design Decisions

1. **Pool size = worker_count + 1**: Each `worker_loop()` and `cleanup_loop()` is a long-running blocking task occupying one thread permanently
2. **Condition variables retained**: `worker_cv_`/`cleanup_cv_` still needed for inter-thread signaling; `thread_adapter` replaces thread creation, not synchronization
3. **IExecutor path preserved**: Backward compatible for users injecting their own executor

## Test Plan
- [x] All 54 queue_manager_test cases pass (including previously failing NackMaxRetries)
- [x] WorkerThreadTest.WorkersProcessMessages - verifies message delivery via thread_adapter
- [x] WorkerThreadTest.WorkersCleanShutdown - verifies clean worker start/stop lifecycle
- [x] WorkerThreadTest.WorkersHandleMultipleMessages - verifies concurrent multi-message processing
- [ ] CI full test suite pass

Closes #282