### PR TITLE
refactor(mpps_handler): remove executor ifdefs and PACS_BRIDGE_STANDALONE_BUILD guards (#335)

### DIFF
--- a/include/pacs/bridge/pacs_adapter/mpps_handler.h
+++ b/include/pacs/bridge/pacs_adapter/mpps_handler.h
@@ -38,11 +38,6 @@ namespace pacs::bridge::integration {
 class mpps_adapter;
 }
 
-// IExecutor interface for task execution (when available)
-#ifndef PACS_BRIDGE_STANDALONE_BUILD
-#include <kcenon/common/interfaces/executor_interface.h>
-#endif
-
 namespace pacs::bridge::pacs_adapter {
 
 // =============================================================================
@@ -430,14 +425,6 @@ struct mpps_handler_config {
     /** MPPS adapter for persistence (nullptr = create default via create_pacs_adapter()) */
     std::shared_ptr<integration::mpps_adapter> mpps_adapter;
 
-    // =========================================================================
-    // Executor Options (IExecutor integration)
-    // =========================================================================
-
-#ifndef PACS_BRIDGE_STANDALONE_BUILD
-    /** Optional executor for task execution (nullptr = use internal std::thread) */
-    std::shared_ptr<kcenon::common::interfaces::IExecutor> executor;
-#endif
 };
 
 // =============================================================================


### PR DESCRIPTION
Closes #335

## Summary
- Remove all `#ifndef PACS_BRIDGE_STANDALONE_BUILD` conditional compilation from `mpps_handler.h` and `mpps_handler.cpp`
- Remove `mpps_monitor_job` class (IExecutor-based IJob implementation)
- Remove `schedule_monitor_job()` method and `monitor_future_` member
- Remove `executor` field from `mpps_handler_config`
- Remove `#include <kcenon/common/interfaces/executor_interface.h>`
- Keep the existing `std::thread`-based monitor as the unified implementation

## Changes
| File | Change |
|------|--------|
| `include/pacs/bridge/pacs_adapter/mpps_handler.h` | Remove executor include, remove executor config field (-13 lines) |
| `src/pacs_adapter/mpps_handler.cpp` | Remove mpps_monitor_job, schedule_monitor_job, ifdef blocks (-79 lines) |

## Impact
- **Net -92 lines** removed
- Zero conditional compilation remaining in mpps_handler (`#ifdef` count: 0)
- All 33 mpps_handler_test tests pass unchanged
- All 39 pacs_adapter_test tests pass unchanged

## Test Plan
- [x] `build/bin/mpps_handler_test` - 33/33 passed
- [x] `build/bin/pacs_adapter_test` - 39/39 passed
- [x] Full standalone build succeeds