### PR TITLE
test(e2e): implement E2E workflow tests for Phase 5c (#321)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1172,3 +1172,10 @@ message(STATUS "")
 
 # Add MLLP test subdirectory
 add_subdirectory(mllp)
+
+# =============================================================================
+# E2E Workflow Tests (Issue #321, Phase 5c)
+# =============================================================================
+
+# Add E2E workflow test subdirectory
+add_subdirectory(e2e)

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -1,0 +1,73 @@
+# =============================================================================
+# tests/e2e/CMakeLists.txt
+# End-to-End Workflow Tests (Phase 5c - Issue #321)
+# =============================================================================
+#
+# E2E workflow tests that validate complete business scenarios:
+#   - HL7 ORM -> MWL -> MPPS -> HL7 response (IHE Scheduled Workflow)
+#   - FHIR ServiceRequest -> MWL -> MPPS -> DiagnosticReport
+#   - Error recovery and resilience scenarios
+#
+# =============================================================================
+
+# Macro for E2E workflow tests
+# Uses custom test framework (consistent with existing e2e_scenario_test)
+macro(add_e2e_test TEST_NAME)
+    set(_E2E_LABELS "integration;e2e;workflow;phase5c")
+    set(_E2E_TIMEOUT 600)
+    if(ARGC GREATER 1)
+        set(_E2E_LABELS "${ARGV1}")
+    endif()
+    if(ARGC GREATER 2)
+        set(_E2E_TIMEOUT "${ARGV2}")
+    endif()
+
+    add_executable(${TEST_NAME} ${TEST_NAME}.cpp)
+
+    target_link_libraries(${TEST_NAME}
+        PRIVATE
+            pacs_bridge
+            pacs_bridge_compile_options
+            GTest::gtest
+            GTest::gmock_main
+    )
+
+    target_include_directories(${TEST_NAME}
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/../integration
+            ${CMAKE_CURRENT_SOURCE_DIR}/../utils
+    )
+
+    target_compile_definitions(${TEST_NAME}
+        PRIVATE
+            PACS_BRIDGE_TEST_DATA_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../data"
+    )
+
+    add_test(
+        NAME ${TEST_NAME}
+        COMMAND ${TEST_NAME}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+    )
+
+    set_tests_properties(${TEST_NAME} PROPERTIES
+        TIMEOUT ${_E2E_TIMEOUT}
+        LABELS "${_E2E_LABELS}"
+    )
+endmacro()
+
+# HL7 to MPPS E2E Workflow Tests
+# Tests complete IHE Scheduled Workflow: HL7 ORM -> MWL -> MPPS -> HL7 response
+add_e2e_test(hl7_to_mpps_workflow_test "integration;e2e;workflow;hl7;mpps;phase5c" 600)
+
+# FHIR Workflow E2E Tests
+# Tests FHIR-based workflow: ServiceRequest -> MWL -> MPPS -> DiagnosticReport
+add_e2e_test(fhir_workflow_test "integration;e2e;workflow;fhir;emr;phase5c" 600)
+
+# =============================================================================
+# Test Summary
+# =============================================================================
+
+message(STATUS "")
+message(STATUS "Phase 5c E2E Workflow Tests (Issue #321):")
+message(STATUS "  - hl7_to_mpps_workflow_test (IHE Scheduled Workflow)")
+message(STATUS "  - fhir_workflow_test (FHIR workflow)")

--- a/tests/e2e/fhir_workflow_test.cpp
+++ b/tests/e2e/fhir_workflow_test.cpp
@@ -1,0 +1,714 @@
+/**
+ * @file fhir_workflow_test.cpp
+ * @brief End-to-end workflow tests for FHIR-based clinical scenarios
+ *
+ * Tests FHIR-centric workflows:
+ *   1. FHIR ServiceRequest -> MWL creation -> MPPS lifecycle
+ *   2. MPPS completion -> DiagnosticReport building -> result posting
+ *   3. Patient lookup -> MWL demographics enrichment
+ *   4. Multi-system integration (HIS, PACS, EMR)
+ *   5. Error handling: incomplete data, transient failures
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/321
+ */
+
+#include "integration_test_base.h"
+#include "pacs_system_test_base.h"
+
+#include "pacs/bridge/emr/diagnostic_report_builder.h"
+#include "pacs/bridge/emr/emr_types.h"
+#include "pacs/bridge/emr/patient_lookup.h"
+#include "pacs/bridge/emr/result_tracker.h"
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pacs::bridge::e2e::test {
+
+using namespace pacs::bridge::integration::test;
+using namespace pacs::bridge::emr;
+
+// =============================================================================
+// Test Macros
+// =============================================================================
+
+#define FHIR_E2E_ASSERT(condition, message)                                    \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            std::cerr << "FAILED: " << message << " at " << __FILE__ << ":"    \
+                      << __LINE__ << std::endl;                                \
+            return false;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define RUN_FHIR_TEST(test_func)                                               \
+    do {                                                                       \
+        std::cout << "Running " << #test_func << "..." << std::endl;           \
+        auto start = std::chrono::high_resolution_clock::now();                \
+        bool result = test_func();                                             \
+        auto end = std::chrono::high_resolution_clock::now();                  \
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>( \
+            end - start);                                                      \
+        if (result) {                                                          \
+            std::cout << "  PASSED (" << duration.count() << "ms)"             \
+                      << std::endl;                                            \
+            passed++;                                                          \
+        } else {                                                               \
+            std::cout << "  FAILED (" << duration.count() << "ms)"             \
+                      << std::endl;                                            \
+            failed++;                                                          \
+        }                                                                      \
+    } while (0)
+
+// =============================================================================
+// Test Utilities
+// =============================================================================
+
+/**
+ * @brief Create a test patient record for FHIR workflow
+ */
+patient_record create_fhir_test_patient(const std::string& id,
+                                        const std::string& mrn,
+                                        const std::string& family,
+                                        const std::string& given) {
+    patient_record patient;
+    patient.id = id;
+    patient.mrn = mrn;
+    patient.active = true;
+    patient.sex = "male";
+    patient.birth_date = "1980-03-15";
+
+    patient_name name;
+    name.family = family;
+    name.given = {given};
+    name.use = "official";
+    patient.names.push_back(name);
+
+    patient_identifier mrn_id;
+    mrn_id.value = mrn;
+    mrn_id.system = "http://hospital.example.org/mrn";
+    mrn_id.type_code = "MR";
+    patient.identifiers.push_back(mrn_id);
+
+    return patient;
+}
+
+/**
+ * @brief Create a test study result for FHIR workflow
+ */
+study_result create_fhir_test_study_result(const std::string& study_uid,
+                                           const std::string& patient_id,
+                                           const std::string& accession,
+                                           const std::string& modality) {
+    study_result result;
+    result.study_instance_uid = study_uid;
+    result.patient_id = patient_id;
+    result.patient_reference = "Patient/" + patient_id;
+    result.accession_number = accession;
+    result.modality = modality;
+    result.study_description = modality + " Study";
+    result.study_datetime = "2026-02-07T10:00:00Z";
+    result.performing_physician = "Dr. Test Radiologist";
+    result.conclusion = "No significant abnormalities identified.";
+    result.status = result_status::final_report;
+    return result;
+}
+
+// =============================================================================
+// Test: Complete FHIR ServiceRequest to DiagnosticReport Workflow
+// =============================================================================
+
+/**
+ * @brief Test complete FHIR workflow from ServiceRequest to DiagnosticReport
+ *
+ * Simulates:
+ *   1. FHIR ServiceRequest received (order placement)
+ *   2. Patient demographics looked up from EMR
+ *   3. MWL entry created with patient data
+ *   4. MPPS lifecycle (IN PROGRESS -> COMPLETED)
+ *   5. DiagnosticReport built with study results
+ *   6. Result tracked for status monitoring
+ */
+bool test_fhir_service_request_to_diagnostic_report() {
+    // Step 1: Simulate FHIR ServiceRequest (order data)
+    std::string accession = pacs_system_test_fixture::generate_unique_accession();
+    std::string patient_id = "fhir-patient-001";
+    std::string study_uid = "1.2.840.113619.2.55.3." + accession;
+
+    // Step 2: Patient demographics (simulating EMR lookup)
+    auto patient = create_fhir_test_patient(
+        patient_id, "MRN-FHIR-001", "Johnson", "Robert");
+    FHIR_E2E_ASSERT(!patient.mrn.empty(), "Patient should have MRN");
+    FHIR_E2E_ASSERT(!patient.names.empty(), "Patient should have name");
+
+    auto official_name = patient.official_name();
+    FHIR_E2E_ASSERT(official_name != nullptr,
+                     "Patient should have official name");
+    FHIR_E2E_ASSERT(official_name->family.value_or("") == "Johnson",
+                     "Family name should be Johnson");
+
+    // Step 3: Create MWL entry with patient data
+    auto mwl_config = pacs_system_test_fixture::create_mwl_test_config();
+    pacs_adapter::mwl_client mwl_client(mwl_config);
+    (void)mwl_client.connect();
+
+    auto mwl_item = mwl_test_data_generator::create_item_with_accession(accession);
+    mwl_item.patient.patient_id = patient.mrn;
+    mwl_item.patient.patient_name = "JOHNSON^ROBERT";
+    mwl_item.patient.patient_birth_date = "19800315";
+    mwl_item.patient.patient_sex = "M";
+    if (!mwl_item.scheduled_steps.empty()) {
+        mwl_item.scheduled_steps[0].modality = "DX";
+        mwl_item.scheduled_steps[0].scheduled_station_ae_title = "DX_ROOM_1";
+    }
+
+    auto add_result = mwl_client.add_entry(mwl_item);
+    FHIR_E2E_ASSERT(add_result.has_value(), "MWL entry should be created");
+
+    // Step 4: MPPS lifecycle
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    auto mpps_dataset = mpps_test_data_generator::create_in_progress();
+    mpps_dataset.accession_number = accession;
+    mpps_dataset.patient_id = patient.mrn;
+    mpps_dataset.patient_name = "JOHNSON^ROBERT";
+    mpps_dataset.modality = "DX";
+    mpps_dataset.study_instance_uid = study_uid;
+
+    auto create_result = mpps_handler->on_n_create(mpps_dataset);
+    FHIR_E2E_ASSERT(create_result.has_value(), "MPPS N-CREATE should succeed");
+
+    // Complete MPPS
+    mpps_dataset.status = pacs_adapter::mpps_event::completed;
+    mpps_dataset.end_date = mpps_test_data_generator::get_today_date();
+    mpps_dataset.end_time = mpps_test_data_generator::get_offset_time(25);
+
+    auto set_result = mpps_handler->on_n_set(mpps_dataset);
+    FHIR_E2E_ASSERT(set_result.has_value(), "MPPS N-SET COMPLETED should succeed");
+
+    // Step 5: Build DiagnosticReport
+    auto study = create_fhir_test_study_result(
+        study_uid, patient_id, accession, "DX");
+
+    diagnostic_report_builder builder;
+    builder.subject("Patient/" + patient_id)
+        .status(result_status::final_report)
+        .code_loinc("36643-5", "Chest X-ray 2 Views")
+        .conclusion(study.conclusion.value_or(""))
+        .effective_datetime(study.study_datetime)
+        .issued(study.study_datetime)
+        .performer("Practitioner/prac-001",
+                   study.performing_physician.value_or(""))
+        .imaging_study("ImagingStudy/img-" + study_uid)
+        .based_on("ServiceRequest/sr-" + accession);
+
+    auto report_json = builder.build();
+    FHIR_E2E_ASSERT(report_json.has_value(),
+                     "DiagnosticReport should be generated");
+    FHIR_E2E_ASSERT(report_json->find("DiagnosticReport") != std::string::npos,
+                     "Should contain DiagnosticReport resource type");
+    FHIR_E2E_ASSERT(report_json->find("Patient/" + patient_id) != std::string::npos,
+                     "Should reference correct patient");
+    FHIR_E2E_ASSERT(report_json->find("final") != std::string::npos,
+                     "Should have final status");
+    FHIR_E2E_ASSERT(report_json->find("36643-5") != std::string::npos,
+                     "Should have LOINC code");
+
+    // Step 6: Track result
+    result_tracker_config tracker_config;
+    tracker_config.max_entries = 1000;
+    tracker_config.ttl = std::chrono::hours{24};
+
+    in_memory_result_tracker tracker(tracker_config);
+
+    posted_result posted;
+    posted.report_id = "report-" + accession;
+    posted.study_instance_uid = study_uid;
+    posted.accession_number = accession;
+    posted.status = result_status::final_report;
+    posted.posted_at = std::chrono::system_clock::now();
+
+    auto track_result = tracker.track(posted);
+    FHIR_E2E_ASSERT(track_result.is_ok(), "Result tracking should succeed");
+
+    auto tracked = tracker.get_by_study_uid(study_uid);
+    FHIR_E2E_ASSERT(tracked.has_value(), "Tracked result should be findable");
+    FHIR_E2E_ASSERT(tracked->status == result_status::final_report,
+                     "Tracked status should be final");
+    FHIR_E2E_ASSERT(tracked->accession_number == accession,
+                     "Accession number should match");
+
+    mpps_handler->stop();
+    mwl_client.disconnect();
+    return true;
+}
+
+// =============================================================================
+// Test: Patient Lookup Integration
+// =============================================================================
+
+/**
+ * @brief Test patient lookup and data validation for MWL creation
+ */
+bool test_patient_lookup_for_mwl_creation() {
+    // Create patient with multiple identifiers
+    auto patient = create_fhir_test_patient(
+        "patient-002", "MRN-FHIR-002", "Kim", "Seonghyun");
+
+    // Add additional identifier
+    patient_identifier other_id;
+    other_id.value = "INS-12345";
+    other_id.system = "http://hospital.example.org/insurance";
+    other_id.type_code = "AN";
+    patient.identifiers.push_back(other_id);
+
+    // Validate patient is suitable for MWL
+    FHIR_E2E_ASSERT(!patient.mrn.empty(),
+                     "Patient should have MRN for MWL");
+    FHIR_E2E_ASSERT(patient.active,
+                     "Patient should be active for MWL");
+    FHIR_E2E_ASSERT(!patient.names.empty() &&
+                         patient.names[0].family.has_value(),
+                     "Patient should have family name");
+    FHIR_E2E_ASSERT(patient.identifiers.size() >= 2,
+                     "Patient should have multiple identifiers");
+
+    // Verify patient query capabilities
+    patient_query query;
+    query.patient_id = patient.mrn;
+    query.identifier_system = "http://hospital.example.org/mrn";
+
+    FHIR_E2E_ASSERT(!query.is_empty(),
+                     "Patient query should have criteria");
+    FHIR_E2E_ASSERT(query.is_mrn_lookup(),
+                     "Should be recognized as MRN lookup");
+
+    // Create MWL with patient demographics
+    auto mwl_config = pacs_system_test_fixture::create_mwl_test_config();
+    pacs_adapter::mwl_client mwl_client(mwl_config);
+    (void)mwl_client.connect();
+
+    std::string accession = pacs_system_test_fixture::generate_unique_accession();
+    auto mwl_item = mwl_test_data_generator::create_item_with_accession(accession);
+    mwl_item.patient.patient_id = patient.mrn;
+    mwl_item.patient.patient_name = "KIM^SEONGHYUN";
+    mwl_item.patient.patient_birth_date = "19800315";
+    mwl_item.patient.patient_sex = "M";
+
+    auto result = mwl_client.add_entry(mwl_item);
+    FHIR_E2E_ASSERT(result.has_value(),
+                     "MWL entry with patient demographics should be created");
+
+    // Verify demographics in MWL
+    pacs_adapter::mwl_query_filter filter;
+    filter.accession_number = accession;
+    auto query_result = mwl_client.query(filter);
+    FHIR_E2E_ASSERT(query_result.has_value() &&
+                         query_result->items.size() == 1,
+                     "Should find MWL entry");
+    FHIR_E2E_ASSERT(query_result->items[0].patient.patient_id == patient.mrn,
+                     "MWL patient ID should match EMR MRN");
+
+    mwl_client.disconnect();
+    return true;
+}
+
+// =============================================================================
+// Test: DiagnosticReport with Multiple Observations
+// =============================================================================
+
+/**
+ * @brief Test building a DiagnosticReport with comprehensive findings
+ */
+bool test_diagnostic_report_comprehensive_build() {
+    auto study = create_fhir_test_study_result(
+        "1.2.840.10008.99.1", "patient-003", "ACC-COMP-001", "CT");
+
+    // Build comprehensive report
+    diagnostic_report_builder builder;
+    builder.subject("Patient/patient-003")
+        .encounter("Encounter/enc-003")
+        .status(result_status::final_report)
+        .code_loinc("24627-2", "CT Chest")
+        .conclusion("1. No pulmonary embolism. "
+                     "2. Mild bilateral pleural effusions. "
+                     "3. No significant lymphadenopathy.")
+        .effective_datetime("2026-02-07T10:00:00Z")
+        .issued("2026-02-07T14:30:00Z")
+        .performer("Practitioner/prac-002", "Dr. Diagnostic")
+        .imaging_study("ImagingStudy/img-001")
+        .based_on("ServiceRequest/sr-003");
+
+    auto report_json = builder.build();
+    FHIR_E2E_ASSERT(report_json.has_value(),
+                     "Comprehensive report should build successfully");
+
+    // Verify all required FHIR fields
+    FHIR_E2E_ASSERT(report_json->find("resourceType") != std::string::npos,
+                     "Should have resourceType");
+    FHIR_E2E_ASSERT(report_json->find("subject") != std::string::npos,
+                     "Should have subject");
+    FHIR_E2E_ASSERT(report_json->find("encounter") != std::string::npos,
+                     "Should have encounter");
+    FHIR_E2E_ASSERT(report_json->find("final") != std::string::npos,
+                     "Should have final status");
+    FHIR_E2E_ASSERT(report_json->find("24627-2") != std::string::npos,
+                     "Should have LOINC code");
+    FHIR_E2E_ASSERT(report_json->find("conclusion") != std::string::npos,
+                     "Should have conclusion");
+    FHIR_E2E_ASSERT(report_json->find("performer") != std::string::npos,
+                     "Should have performer");
+    FHIR_E2E_ASSERT(report_json->find("imagingStudy") != std::string::npos,
+                     "Should have imaging study reference");
+
+    return true;
+}
+
+// =============================================================================
+// Test: Result Status Lifecycle (Preliminary -> Final -> Amended)
+// =============================================================================
+
+/**
+ * @brief Test result status progression through lifecycle stages
+ */
+bool test_result_status_lifecycle() {
+    result_tracker_config config;
+    config.max_entries = 1000;
+    config.ttl = std::chrono::hours{24};
+    in_memory_result_tracker tracker(config);
+
+    std::string study_uid = "1.2.840.10008.99.LIFECYCLE";
+    std::string accession = "ACC-LIFECYCLE-001";
+
+    // Stage 1: Preliminary result
+    {
+        posted_result preliminary;
+        preliminary.report_id = "report-prelim-001";
+        preliminary.study_instance_uid = study_uid;
+        preliminary.accession_number = accession;
+        preliminary.status = result_status::preliminary;
+        preliminary.posted_at = std::chrono::system_clock::now();
+
+        auto result = tracker.track(preliminary);
+        FHIR_E2E_ASSERT(result.is_ok(), "Preliminary tracking should succeed");
+
+        auto tracked = tracker.get_by_study_uid(study_uid);
+        FHIR_E2E_ASSERT(tracked.has_value() &&
+                             tracked->status == result_status::preliminary,
+                         "Should be preliminary status");
+    }
+
+    // Stage 2: Final result (update)
+    {
+        posted_result final_result;
+        final_result.report_id = "report-final-001";
+        final_result.study_instance_uid = study_uid;
+        final_result.accession_number = accession;
+        final_result.status = result_status::final_report;
+        final_result.posted_at = std::chrono::system_clock::now();
+
+        auto result = tracker.track(final_result);
+        FHIR_E2E_ASSERT(result.is_ok(), "Final tracking should succeed");
+
+        auto tracked = tracker.get_by_study_uid(study_uid);
+        FHIR_E2E_ASSERT(tracked.has_value() &&
+                             tracked->status == result_status::final_report,
+                         "Should be final status after update");
+    }
+
+    // Stage 3: Amended result (correction)
+    {
+        posted_result amended;
+        amended.report_id = "report-amended-001";
+        amended.study_instance_uid = study_uid;
+        amended.accession_number = accession;
+        amended.status = result_status::amended;
+        amended.posted_at = std::chrono::system_clock::now();
+
+        auto result = tracker.track(amended);
+        FHIR_E2E_ASSERT(result.is_ok(), "Amended tracking should succeed");
+
+        auto tracked = tracker.get_by_study_uid(study_uid);
+        FHIR_E2E_ASSERT(tracked.has_value() &&
+                             tracked->status == result_status::amended,
+                         "Should be amended status after correction");
+    }
+
+    return true;
+}
+
+// =============================================================================
+// Test: Multi-System Integration (HIS + PACS + EMR)
+// =============================================================================
+
+/**
+ * @brief Test complete multi-system workflow spanning HIS, PACS, and EMR
+ *
+ * Validates the full data flow:
+ *   HIS (order) -> PACS Bridge (MWL/MPPS) -> EMR (result)
+ */
+bool test_multi_system_his_pacs_emr_workflow() {
+    // Setup mock servers for RIS and EMR via MLLP
+    uint16_t ris_port = integration_test_fixture::generate_test_port();
+    uint16_t emr_port = integration_test_fixture::generate_test_port();
+
+    mock_ris_server::config ris_config;
+    ris_config.port = ris_port;
+    mock_ris_server ris(ris_config);
+
+    mock_ris_server::config emr_config;
+    emr_config.port = emr_port;
+    mock_ris_server emr(emr_config);
+
+    ris.start();
+    emr.start();
+    integration_test_fixture::wait_for(
+        [&ris, &emr]() { return ris.is_running() && emr.is_running(); },
+        std::chrono::milliseconds{2000});
+
+    std::string accession = pacs_system_test_fixture::generate_unique_accession();
+    std::string patient_id = "MULTI_SYS_PAT_001";
+    std::string study_uid = "1.2.840.10008.99.MULTI." + accession;
+
+    // --- HIS Phase: Order placement (ORM via MLLP to PACS Bridge) ---
+
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = ris_port;
+        mllp::mllp_client client(client_config);
+
+        FHIR_E2E_ASSERT(client.connect().has_value(),
+                         "Should connect to RIS");
+
+        auto now = std::chrono::system_clock::now();
+        auto time_t_now = std::chrono::system_clock::to_time_t(now);
+        char timestamp[15];
+        std::strftime(timestamp, sizeof(timestamp), "%Y%m%d%H%M%S",
+                      std::localtime(&time_t_now));
+
+        std::string orm_msg =
+            "MSH|^~\\&|HIS|HOSPITAL|RIS|RADIOLOGY|" +
+            std::string(timestamp) +
+            "||ORM^O01|MULTI_001|P|2.4\r"
+            "PID|1||" + patient_id + "|||MULTI^SYSTEM^PATIENT\r"
+            "ORC|NW|ORD_MULTI_001||" + accession + "||SC\r"
+            "OBR|1|ORD_MULTI_001||DX-CHEST\r";
+        auto msg = mllp::mllp_message::from_string(orm_msg);
+        auto send_result = client.send(msg);
+        FHIR_E2E_ASSERT(send_result.has_value(),
+                         "Order should be sent to RIS");
+        client.disconnect();
+    }
+
+    FHIR_E2E_ASSERT(ris.messages_received() >= 1,
+                     "RIS should receive order");
+
+    // --- PACS Phase: MWL + MPPS lifecycle ---
+
+    auto mwl_config = pacs_system_test_fixture::create_mwl_test_config();
+    pacs_adapter::mwl_client mwl_client(mwl_config);
+    (void)mwl_client.connect();
+
+    auto mwl_item = mwl_test_data_generator::create_item_with_accession(accession);
+    mwl_item.patient.patient_id = patient_id;
+    mwl_item.patient.patient_name = "MULTI^SYSTEM^PATIENT";
+    (void)mwl_client.add_entry(mwl_item);
+
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    auto mpps_dataset = mpps_test_data_generator::create_in_progress();
+    mpps_dataset.accession_number = accession;
+    mpps_dataset.patient_id = patient_id;
+    mpps_dataset.study_instance_uid = study_uid;
+    mpps_dataset.modality = "DX";
+
+    (void)mpps_handler->on_n_create(mpps_dataset);
+
+    mpps_dataset.status = pacs_adapter::mpps_event::completed;
+    mpps_dataset.end_date = mpps_test_data_generator::get_today_date();
+    mpps_dataset.end_time = mpps_test_data_generator::get_offset_time(20);
+    (void)mpps_handler->on_n_set(mpps_dataset);
+
+    // --- EMR Phase: DiagnosticReport and result delivery ---
+
+    // Build FHIR DiagnosticReport
+    diagnostic_report_builder builder;
+    builder.subject("Patient/" + patient_id)
+        .status(result_status::final_report)
+        .code_loinc("36643-5", "Chest X-ray 2 Views")
+        .conclusion("No acute cardiopulmonary abnormality.")
+        .effective_datetime("2026-02-07T10:00:00Z");
+
+    auto report_json = builder.build();
+    FHIR_E2E_ASSERT(report_json.has_value(),
+                     "DiagnosticReport should be built");
+
+    // Send ORU result to EMR
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = emr_port;
+        mllp::mllp_client client(client_config);
+
+        FHIR_E2E_ASSERT(client.connect().has_value(),
+                         "Should connect to EMR");
+
+        auto now = std::chrono::system_clock::now();
+        auto time_t_now = std::chrono::system_clock::to_time_t(now);
+        char timestamp[15];
+        std::strftime(timestamp, sizeof(timestamp), "%Y%m%d%H%M%S",
+                      std::localtime(&time_t_now));
+
+        std::string oru_msg =
+            "MSH|^~\\&|PACS|RADIOLOGY|EMR|HOSPITAL|" +
+            std::string(timestamp) +
+            "||ORU^R01|MULTI_RES_001|P|2.4\r"
+            "PID|1||" + patient_id + "|||MULTI^SYSTEM^PATIENT\r"
+            "OBR|1|ORD_MULTI_001|ORD_MULTI_001|DX-CHEST|||" +
+            std::string(timestamp) + "|||||||||||||||F\r"
+            "OBX|1|TX|IMPRESSION||NO ACUTE CARDIOPULMONARY ABNORMALITY||||||F\r";
+        auto msg = mllp::mllp_message::from_string(oru_msg);
+        auto send_result = client.send(msg);
+        FHIR_E2E_ASSERT(send_result.has_value(),
+                         "Result should be sent to EMR");
+        client.disconnect();
+    }
+
+    FHIR_E2E_ASSERT(emr.messages_received() >= 1,
+                     "EMR should receive result");
+
+    // Track result
+    result_tracker_config tracker_config;
+    tracker_config.max_entries = 1000;
+    tracker_config.ttl = std::chrono::hours{24};
+    in_memory_result_tracker tracker(tracker_config);
+
+    posted_result posted;
+    posted.report_id = "report-multi-" + accession;
+    posted.study_instance_uid = study_uid;
+    posted.accession_number = accession;
+    posted.status = result_status::final_report;
+    posted.posted_at = std::chrono::system_clock::now();
+
+    auto track_result = tracker.track(posted);
+    FHIR_E2E_ASSERT(track_result.is_ok(), "Result tracking should succeed");
+
+    mpps_handler->stop();
+    mwl_client.disconnect();
+    ris.stop();
+    emr.stop();
+    return true;
+}
+
+// =============================================================================
+// Test: Incomplete Study Result Validation
+// =============================================================================
+
+/**
+ * @brief Test validation catches incomplete study results
+ */
+bool test_incomplete_study_result_handling() {
+    // Result with missing required fields
+    study_result incomplete;
+    incomplete.study_instance_uid = "1.2.3.4.5";
+    // Missing: patient_id, modality, study_datetime, etc.
+
+    FHIR_E2E_ASSERT(!incomplete.is_valid(),
+                     "Incomplete result should fail validation");
+
+    // Result with all required fields
+    auto complete = create_fhir_test_study_result(
+        "1.2.840.10008.99.VALID", "patient-valid", "ACC-VALID", "CT");
+    FHIR_E2E_ASSERT(complete.is_valid(),
+                     "Complete result should pass validation");
+
+    return true;
+}
+
+// =============================================================================
+// Test: Retry Policy Configuration
+// =============================================================================
+
+/**
+ * @brief Test retry policy backoff calculations for transient failures
+ */
+bool test_retry_policy_backoff() {
+    retry_policy policy;
+    policy.max_retries = 5;
+    policy.initial_backoff = std::chrono::milliseconds{100};
+    policy.max_backoff = std::chrono::milliseconds{10000};
+    policy.backoff_multiplier = 2.0;
+
+    FHIR_E2E_ASSERT(policy.max_retries == 5,
+                     "Max retries should be 5");
+
+    // Verify exponential backoff progression
+    auto delay0 = policy.backoff_for(0);
+    auto delay1 = policy.backoff_for(1);
+    auto delay2 = policy.backoff_for(2);
+    auto delay3 = policy.backoff_for(3);
+
+    FHIR_E2E_ASSERT(delay0 < delay1, "Delay should increase");
+    FHIR_E2E_ASSERT(delay1 < delay2, "Delay should keep increasing");
+    FHIR_E2E_ASSERT(delay2 < delay3, "Delay should continue increasing");
+
+    // Verify max backoff cap
+    auto delay_max = policy.backoff_for(100);
+    FHIR_E2E_ASSERT(delay_max <= policy.max_backoff,
+                     "Delay should not exceed max backoff");
+
+    return true;
+}
+
+// =============================================================================
+// Main Test Runner
+// =============================================================================
+
+int run_all_fhir_workflow_tests() {
+    int passed = 0;
+    int failed = 0;
+
+    std::cout << "=============================================" << std::endl;
+    std::cout << "FHIR Workflow E2E Tests" << std::endl;
+    std::cout << "Phase 5c - Issue #321" << std::endl;
+    std::cout << "=============================================" << std::endl;
+
+    std::cout << "\n--- Complete Workflow Tests ---" << std::endl;
+    RUN_FHIR_TEST(test_fhir_service_request_to_diagnostic_report);
+    RUN_FHIR_TEST(test_patient_lookup_for_mwl_creation);
+
+    std::cout << "\n--- DiagnosticReport Tests ---" << std::endl;
+    RUN_FHIR_TEST(test_diagnostic_report_comprehensive_build);
+    RUN_FHIR_TEST(test_result_status_lifecycle);
+
+    std::cout << "\n--- Multi-System Integration ---" << std::endl;
+    RUN_FHIR_TEST(test_multi_system_his_pacs_emr_workflow);
+
+    std::cout << "\n--- Error Handling Tests ---" << std::endl;
+    RUN_FHIR_TEST(test_incomplete_study_result_handling);
+    RUN_FHIR_TEST(test_retry_policy_backoff);
+
+    std::cout << "\n=============================================" << std::endl;
+    std::cout << "Results: " << passed << " passed, " << failed << " failed"
+              << std::endl;
+    std::cout << "Total:  " << (passed + failed) << std::endl;
+    if (passed + failed > 0) {
+        double pass_rate = (passed * 100.0) / (passed + failed);
+        std::cout << "Pass Rate: " << pass_rate << "%" << std::endl;
+    }
+    std::cout << "=============================================" << std::endl;
+
+    return failed > 0 ? 1 : 0;
+}
+
+}  // namespace pacs::bridge::e2e::test
+
+int main() {
+    return pacs::bridge::e2e::test::run_all_fhir_workflow_tests();
+}

--- a/tests/e2e/hl7_to_mpps_workflow_test.cpp
+++ b/tests/e2e/hl7_to_mpps_workflow_test.cpp
@@ -1,0 +1,973 @@
+/**
+ * @file hl7_to_mpps_workflow_test.cpp
+ * @brief End-to-end workflow tests for HL7 -> MWL -> MPPS -> HL7 pipeline
+ *
+ * Tests the complete IHE Scheduled Workflow profile:
+ *   1. HL7 ORM^O01 order received via MLLP -> MWL entry created
+ *   2. Modality queries MWL and starts procedure (MPPS N-CREATE)
+ *   3. MPPS IN PROGRESS persisted -> ORM^O01 (IP) sent to RIS
+ *   4. Modality completes procedure (MPPS N-SET COMPLETED)
+ *   5. MPPS COMPLETED persisted -> ORM^O01 (CM) sent to RIS
+ *   6. Result ORU^R01 sent to EMR
+ *
+ * @see https://github.com/kcenon/pacs_bridge/issues/321
+ * @see docs/reference_materials/06_ihe_swf_profile.md
+ */
+
+#include "integration_test_base.h"
+#include "pacs_system_test_base.h"
+
+#include "pacs/bridge/emr/diagnostic_report_builder.h"
+#include "pacs/bridge/emr/patient_lookup.h"
+#include "pacs/bridge/emr/result_tracker.h"
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pacs::bridge::e2e::test {
+
+using namespace pacs::bridge::integration::test;
+
+// =============================================================================
+// Test Macros
+// =============================================================================
+
+#define E2E_ASSERT(condition, message)                                         \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            std::cerr << "FAILED: " << message << " at " << __FILE__ << ":"    \
+                      << __LINE__ << std::endl;                                \
+            return false;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define RUN_E2E_TEST(test_func)                                                \
+    do {                                                                       \
+        std::cout << "Running " << #test_func << "..." << std::endl;           \
+        auto start = std::chrono::high_resolution_clock::now();                \
+        bool result = test_func();                                             \
+        auto end = std::chrono::high_resolution_clock::now();                  \
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>( \
+            end - start);                                                      \
+        if (result) {                                                          \
+            std::cout << "  PASSED (" << duration.count() << "ms)"             \
+                      << std::endl;                                            \
+            passed++;                                                          \
+        } else {                                                               \
+            std::cout << "  FAILED (" << duration.count() << "ms)"             \
+                      << std::endl;                                            \
+            failed++;                                                          \
+        }                                                                      \
+    } while (0)
+
+// =============================================================================
+// HL7 Message Templates
+// =============================================================================
+
+namespace hl7_templates {
+
+/**
+ * @brief Build ORM^O01 new order message
+ */
+std::string build_orm_new_order(const std::string& patient_id,
+                                const std::string& patient_name,
+                                const std::string& order_id,
+                                const std::string& accession,
+                                const std::string& procedure_code,
+                                const std::string& msg_control_id) {
+    auto now = std::chrono::system_clock::now();
+    auto time_t_now = std::chrono::system_clock::to_time_t(now);
+    char timestamp[15];
+    std::strftime(timestamp, sizeof(timestamp), "%Y%m%d%H%M%S",
+                  std::localtime(&time_t_now));
+
+    return "MSH|^~\\&|HIS|HOSPITAL|PACS|RADIOLOGY|" +
+           std::string(timestamp) +
+           "||ORM^O01|" + msg_control_id + "|P|2.4\r"
+           "PID|1||" + patient_id + "|||" + patient_name + "\r"
+           "ORC|NW|" + order_id + "||" + accession + "||SC\r"
+           "OBR|1|" + order_id + "||" + procedure_code + "\r";
+}
+
+/**
+ * @brief Build ORM^O01 status update message (IP/CM/DC)
+ */
+std::string build_orm_status_update(const std::string& patient_id,
+                                    const std::string& patient_name,
+                                    const std::string& order_id,
+                                    const std::string& accession,
+                                    const std::string& procedure_code,
+                                    const std::string& status_code,
+                                    const std::string& msg_control_id) {
+    auto now = std::chrono::system_clock::now();
+    auto time_t_now = std::chrono::system_clock::to_time_t(now);
+    char timestamp[15];
+    std::strftime(timestamp, sizeof(timestamp), "%Y%m%d%H%M%S",
+                  std::localtime(&time_t_now));
+
+    return "MSH|^~\\&|PACS|RADIOLOGY|RIS|HOSPITAL|" +
+           std::string(timestamp) +
+           "||ORM^O01|" + msg_control_id + "|P|2.4\r"
+           "PID|1||" + patient_id + "|||" + patient_name + "\r"
+           "ORC|SC|" + order_id + "||" + accession + "||" + status_code + "\r"
+           "OBR|1|" + order_id + "||" + procedure_code + "\r";
+}
+
+/**
+ * @brief Build ORU^R01 result message
+ */
+std::string build_oru_result(const std::string& patient_id,
+                             const std::string& patient_name,
+                             const std::string& order_id,
+                             const std::string& procedure_code,
+                             const std::string& impression,
+                             const std::string& msg_control_id) {
+    auto now = std::chrono::system_clock::now();
+    auto time_t_now = std::chrono::system_clock::to_time_t(now);
+    char timestamp[15];
+    std::strftime(timestamp, sizeof(timestamp), "%Y%m%d%H%M%S",
+                  std::localtime(&time_t_now));
+
+    return "MSH|^~\\&|PACS|RADIOLOGY|EMR|HOSPITAL|" +
+           std::string(timestamp) +
+           "||ORU^R01|" + msg_control_id + "|P|2.4\r"
+           "PID|1||" + patient_id + "|||" + patient_name + "\r"
+           "OBR|1|" + order_id + "|" + order_id + "|" + procedure_code +
+           "|||" + std::string(timestamp) + "|||||||||||||||F\r"
+           "OBX|1|TX|IMPRESSION||" + impression + "||||||F\r";
+}
+
+/**
+ * @brief Build ORM^O01 order cancellation message
+ */
+std::string build_orm_cancel(const std::string& patient_id,
+                             const std::string& patient_name,
+                             const std::string& order_id,
+                             const std::string& accession,
+                             const std::string& procedure_code,
+                             const std::string& msg_control_id) {
+    auto now = std::chrono::system_clock::now();
+    auto time_t_now = std::chrono::system_clock::to_time_t(now);
+    char timestamp[15];
+    std::strftime(timestamp, sizeof(timestamp), "%Y%m%d%H%M%S",
+                  std::localtime(&time_t_now));
+
+    return "MSH|^~\\&|PACS|RADIOLOGY|RIS|HOSPITAL|" +
+           std::string(timestamp) +
+           "||ORM^O01|" + msg_control_id + "|P|2.4\r"
+           "PID|1||" + patient_id + "|||" + patient_name + "\r"
+           "ORC|CA|" + order_id + "||" + accession + "||DC\r"
+           "OBR|1|" + order_id + "||" + procedure_code + "\r";
+}
+
+}  // namespace hl7_templates
+
+// =============================================================================
+// Test: Complete HL7 Order -> MWL -> MPPS -> Result Workflow
+// =============================================================================
+
+/**
+ * @brief Test the complete IHE Scheduled Workflow profile
+ *
+ * Validates the full round-trip:
+ *   HIS --[ORM^O01 NW]--> PACS Bridge --[MWL]--> Create worklist entry
+ *   Modality --[MPPS N-CREATE]--> PACS Bridge --[ORM^O01 IP]--> RIS
+ *   Modality --[MPPS N-SET CM]--> PACS Bridge --[ORM^O01 CM]--> RIS
+ *   PACS Bridge --[ORU^R01]--> EMR
+ */
+bool test_hl7_order_to_mpps_complete_workflow() {
+    // Setup: RIS and EMR mock servers
+    uint16_t ris_port = integration_test_fixture::generate_test_port();
+    uint16_t emr_port = integration_test_fixture::generate_test_port();
+
+    mock_ris_server::config ris_config;
+    ris_config.port = ris_port;
+    ris_config.auto_ack = true;
+    mock_ris_server ris(ris_config);
+
+    mock_ris_server::config emr_config;
+    emr_config.port = emr_port;
+    emr_config.auto_ack = true;
+    mock_ris_server emr(emr_config);
+
+    E2E_ASSERT(ris.start(), "Failed to start RIS server");
+    E2E_ASSERT(emr.start(), "Failed to start EMR server");
+    E2E_ASSERT(
+        integration_test_fixture::wait_for(
+            [&ris, &emr]() { return ris.is_running() && emr.is_running(); },
+            std::chrono::milliseconds{2000}),
+        "Servers should start");
+
+    const std::string patient_id = "E2E_PAT_001";
+    const std::string patient_name = "WORKFLOW^COMPLETE^TEST";
+    const std::string order_id = "E2E_ORD_001";
+    const std::string accession = "E2E_ACC_001";
+    const std::string procedure_code = "CT-CHEST";
+
+    // --- Phase 1: Create MWL entry (simulates HIS order receipt) ---
+
+    auto mwl_config = pacs_system_test_fixture::create_mwl_test_config();
+    pacs_adapter::mwl_client mwl_client(mwl_config);
+    (void)mwl_client.connect();
+
+    auto mwl_item = mwl_test_data_generator::create_item_with_accession(accession);
+    mwl_item.patient.patient_id = patient_id;
+    mwl_item.patient.patient_name = patient_name;
+    if (!mwl_item.scheduled_steps.empty()) {
+        mwl_item.scheduled_steps[0].modality = "CT";
+        mwl_item.scheduled_steps[0].scheduled_station_ae_title = "CT_SCANNER_1";
+    }
+
+    auto add_result = mwl_client.add_entry(mwl_item);
+    E2E_ASSERT(add_result.has_value(), "MWL entry should be created");
+
+    // Verify MWL entry is queryable
+    pacs_adapter::mwl_query_filter filter;
+    filter.accession_number = accession;
+    auto mwl_query = mwl_client.query(filter);
+    E2E_ASSERT(mwl_query.has_value() && mwl_query->items.size() == 1,
+               "MWL entry should be queryable");
+    E2E_ASSERT(mwl_query->items[0].patient.patient_id == patient_id,
+               "MWL patient ID should match");
+
+    // --- Phase 2: MPPS N-CREATE (procedure starts) ---
+
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    std::vector<std::pair<std::string, std::string>> mpps_events;
+    std::mutex events_mutex;
+    mpps_handler->set_callback(
+        [&mpps_events, &events_mutex](pacs_adapter::mpps_event event,
+                                      const pacs_adapter::mpps_dataset& dataset) {
+            std::lock_guard<std::mutex> lock(events_mutex);
+            mpps_events.emplace_back(pacs_adapter::to_string(event),
+                                     dataset.accession_number);
+        });
+
+    auto mpps_dataset = mpps_test_data_generator::create_in_progress();
+    mpps_dataset.accession_number = accession;
+    mpps_dataset.patient_id = patient_id;
+    mpps_dataset.patient_name = patient_name;
+    std::string sop_uid = mpps_dataset.sop_instance_uid;
+
+    auto create_result = mpps_handler->on_n_create(mpps_dataset);
+    E2E_ASSERT(create_result.has_value(), "MPPS N-CREATE should succeed");
+
+    // Verify MPPS persisted as IN PROGRESS
+    auto mpps_query = mpps_handler->query_mpps(sop_uid);
+    E2E_ASSERT(mpps_query.has_value() && mpps_query->has_value(),
+               "MPPS record should exist");
+    E2E_ASSERT(mpps_query->value().status ==
+                   pacs_adapter::mpps_event::in_progress,
+               "MPPS status should be IN PROGRESS");
+
+    // --- Phase 3: Send ORM^O01 IP to RIS (status update) ---
+
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = ris_port;
+        mllp::mllp_client client(client_config);
+
+        E2E_ASSERT(client.connect().has_value(), "Should connect to RIS");
+
+        auto orm_ip = hl7_templates::build_orm_status_update(
+            patient_id, patient_name, order_id, accession,
+            procedure_code, "IP", "E2E_MSG_001");
+        auto msg = mllp::mllp_message::from_string(orm_ip);
+        auto send_result = client.send(msg);
+        E2E_ASSERT(send_result.has_value(),
+                    "Should send IP status update to RIS");
+        client.disconnect();
+    }
+
+    E2E_ASSERT(ris.messages_received() >= 1,
+               "RIS should receive IP status update");
+
+    // --- Phase 4: MPPS N-SET COMPLETED (procedure finishes) ---
+
+    mpps_dataset.status = pacs_adapter::mpps_event::completed;
+    mpps_dataset.end_date = mpps_test_data_generator::get_today_date();
+    mpps_dataset.end_time = mpps_test_data_generator::get_offset_time(30);
+
+    auto set_result = mpps_handler->on_n_set(mpps_dataset);
+    E2E_ASSERT(set_result.has_value(), "MPPS N-SET COMPLETED should succeed");
+
+    // Verify MPPS persisted as COMPLETED
+    auto mpps_query2 = mpps_handler->query_mpps(sop_uid);
+    E2E_ASSERT(mpps_query2.has_value() && mpps_query2->has_value(),
+               "MPPS record should still exist");
+    E2E_ASSERT(mpps_query2->value().status ==
+                   pacs_adapter::mpps_event::completed,
+               "MPPS status should be COMPLETED");
+
+    // --- Phase 5: Send ORM^O01 CM to RIS (completion) ---
+
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = ris_port;
+        mllp::mllp_client client(client_config);
+
+        E2E_ASSERT(client.connect().has_value(), "Should connect to RIS");
+
+        auto orm_cm = hl7_templates::build_orm_status_update(
+            patient_id, patient_name, order_id, accession,
+            procedure_code, "CM", "E2E_MSG_002");
+        auto msg = mllp::mllp_message::from_string(orm_cm);
+        auto send_result = client.send(msg);
+        E2E_ASSERT(send_result.has_value(),
+                    "Should send CM status update to RIS");
+        client.disconnect();
+    }
+
+    E2E_ASSERT(ris.messages_received() >= 2,
+               "RIS should receive CM status update");
+
+    // --- Phase 6: Send ORU^R01 result to EMR ---
+
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = emr_port;
+        mllp::mllp_client client(client_config);
+
+        E2E_ASSERT(client.connect().has_value(), "Should connect to EMR");
+
+        auto oru_msg = hl7_templates::build_oru_result(
+            patient_id, patient_name, order_id, procedure_code,
+            "NO ACUTE FINDINGS", "E2E_MSG_003");
+        auto msg = mllp::mllp_message::from_string(oru_msg);
+        auto send_result = client.send(msg);
+        E2E_ASSERT(send_result.has_value(),
+                    "Should send result to EMR");
+        client.disconnect();
+    }
+
+    E2E_ASSERT(emr.messages_received() >= 1,
+               "EMR should receive result message");
+
+    // --- Verification: MPPS callback events ---
+    {
+        std::lock_guard<std::mutex> lock(events_mutex);
+        E2E_ASSERT(mpps_events.size() >= 2,
+                    "Should have at least 2 MPPS events (IP + CM)");
+    }
+
+    // Cleanup
+    mpps_handler->stop();
+    mwl_client.disconnect();
+    ris.stop();
+    emr.stop();
+    return true;
+}
+
+// =============================================================================
+// Test: Order Cancellation Workflow (MPPS Discontinuation)
+// =============================================================================
+
+/**
+ * @brief Test order cancellation with MPPS discontinuation
+ *
+ * Validates:
+ *   1. MWL entry created for order
+ *   2. MPPS started (IN PROGRESS)
+ *   3. Procedure discontinued (patient refused)
+ *   4. Cancellation message (DC) sent to RIS
+ */
+bool test_hl7_order_cancellation_workflow() {
+    uint16_t ris_port = integration_test_fixture::generate_test_port();
+
+    mock_ris_server::config ris_config;
+    ris_config.port = ris_port;
+    mock_ris_server ris(ris_config);
+
+    E2E_ASSERT(ris.start(), "Failed to start RIS");
+    E2E_ASSERT(
+        integration_test_fixture::wait_for(
+            [&ris]() { return ris.is_running(); },
+            std::chrono::milliseconds{2000}),
+        "RIS should start");
+
+    const std::string patient_id = "E2E_PAT_002";
+    const std::string patient_name = "CANCEL^WORKFLOW^TEST";
+    const std::string order_id = "E2E_ORD_002";
+    const std::string accession = "E2E_ACC_002";
+    const std::string procedure_code = "MR-BRAIN";
+
+    // Create MWL entry
+    auto mwl_config = pacs_system_test_fixture::create_mwl_test_config();
+    pacs_adapter::mwl_client mwl_client(mwl_config);
+    (void)mwl_client.connect();
+
+    auto mwl_item = mwl_test_data_generator::create_item_with_accession(accession);
+    mwl_item.patient.patient_id = patient_id;
+    mwl_item.patient.patient_name = patient_name;
+    if (!mwl_item.scheduled_steps.empty()) {
+        mwl_item.scheduled_steps[0].modality = "MR";
+    }
+    (void)mwl_client.add_entry(mwl_item);
+
+    // Start MPPS (IN PROGRESS)
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    auto mpps_dataset = mpps_test_data_generator::create_in_progress();
+    mpps_dataset.accession_number = accession;
+    mpps_dataset.patient_id = patient_id;
+    mpps_dataset.modality = "MR";
+    std::string sop_uid = mpps_dataset.sop_instance_uid;
+
+    auto create_result = mpps_handler->on_n_create(mpps_dataset);
+    E2E_ASSERT(create_result.has_value(), "N-CREATE should succeed");
+
+    // Discontinue MPPS (patient refused)
+    mpps_dataset.status = pacs_adapter::mpps_event::discontinued;
+    mpps_dataset.end_date = mpps_test_data_generator::get_today_date();
+    mpps_dataset.end_time = mpps_test_data_generator::get_offset_time(5);
+    mpps_dataset.discontinuation_reason = "Patient refused";
+
+    auto set_result = mpps_handler->on_n_set(mpps_dataset);
+    E2E_ASSERT(set_result.has_value(), "N-SET DISCONTINUED should succeed");
+
+    // Verify MPPS status
+    auto mpps_query = mpps_handler->query_mpps(sop_uid);
+    E2E_ASSERT(mpps_query.has_value() && mpps_query->has_value(),
+               "MPPS record should exist");
+    E2E_ASSERT(mpps_query->value().status ==
+                   pacs_adapter::mpps_event::discontinued,
+               "MPPS should be DISCONTINUED");
+    E2E_ASSERT(mpps_query->value().discontinuation_reason == "Patient refused",
+               "Discontinuation reason should match");
+
+    // Send cancellation to RIS
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = ris_port;
+        mllp::mllp_client client(client_config);
+
+        E2E_ASSERT(client.connect().has_value(), "Should connect to RIS");
+
+        auto orm_cancel = hl7_templates::build_orm_cancel(
+            patient_id, patient_name, order_id, accession,
+            procedure_code, "E2E_MSG_010");
+        auto msg = mllp::mllp_message::from_string(orm_cancel);
+        auto send_result = client.send(msg);
+        E2E_ASSERT(send_result.has_value(),
+                    "Should send cancellation to RIS");
+        client.disconnect();
+    }
+
+    E2E_ASSERT(ris.messages_received() >= 1,
+               "RIS should receive cancellation");
+
+    // Verify MWL entry can be cancelled
+    auto cancel_result = mwl_client.cancel_entry(accession);
+    E2E_ASSERT(cancel_result.has_value(), "MWL cancellation should succeed");
+
+    mpps_handler->stop();
+    mwl_client.disconnect();
+    ris.stop();
+    return true;
+}
+
+// =============================================================================
+// Test: Multi-Procedure Concurrent Workflow
+// =============================================================================
+
+/**
+ * @brief Test multiple concurrent procedures across different modalities
+ *
+ * Validates:
+ *   1. Multiple MWL entries created for different patients/modalities
+ *   2. MPPS started independently on CT, MR, US scanners
+ *   3. Procedures complete in arbitrary order
+ *   4. Status updates sent to RIS for each
+ */
+bool test_multi_procedure_concurrent_workflow() {
+    uint16_t ris_port = integration_test_fixture::generate_test_port();
+
+    mock_ris_server::config ris_config;
+    ris_config.port = ris_port;
+    mock_ris_server ris(ris_config);
+
+    E2E_ASSERT(ris.start(), "Failed to start RIS");
+    E2E_ASSERT(
+        integration_test_fixture::wait_for(
+            [&ris]() { return ris.is_running(); },
+            std::chrono::milliseconds{2000}),
+        "RIS should start");
+
+    // Create MWL entries
+    auto mwl_config = pacs_system_test_fixture::create_mwl_test_config();
+    pacs_adapter::mwl_client mwl_client(mwl_config);
+    (void)mwl_client.connect();
+
+    struct procedure_info {
+        std::string patient_id;
+        std::string patient_name;
+        std::string accession;
+        std::string modality;
+        std::string station;
+    };
+
+    std::vector<procedure_info> procedures = {
+        {"E2E_PAT_010", "DOE^JOHN", "E2E_ACC_010", "CT", "CT_SCANNER_1"},
+        {"E2E_PAT_011", "SMITH^JANE", "E2E_ACC_011", "MR", "MR_SCANNER_1"},
+        {"E2E_PAT_012", "WILSON^TOM", "E2E_ACC_012", "US", "US_SCANNER_1"},
+    };
+
+    // Create MWL entries for all procedures
+    for (const auto& proc : procedures) {
+        auto item = mwl_test_data_generator::create_item_with_accession(
+            proc.accession);
+        item.patient.patient_id = proc.patient_id;
+        item.patient.patient_name = proc.patient_name;
+        if (!item.scheduled_steps.empty()) {
+            item.scheduled_steps[0].modality = proc.modality;
+            item.scheduled_steps[0].scheduled_station_ae_title = proc.station;
+        }
+        auto result = mwl_client.add_entry(item);
+        E2E_ASSERT(result.has_value(),
+                    "MWL entry for " + proc.patient_id + " should be created");
+    }
+
+    // Start MPPS for all procedures
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    std::atomic<int> completed_count{0};
+    mpps_handler->set_callback(
+        [&completed_count](pacs_adapter::mpps_event event,
+                           const pacs_adapter::mpps_dataset& /*dataset*/) {
+            if (event == pacs_adapter::mpps_event::completed) {
+                completed_count++;
+            }
+        });
+
+    std::vector<pacs_adapter::mpps_dataset> mpps_datasets;
+    for (const auto& proc : procedures) {
+        auto ds = mpps_test_data_generator::create_with_station(proc.station);
+        ds.accession_number = proc.accession;
+        ds.patient_id = proc.patient_id;
+        ds.patient_name = proc.patient_name;
+        ds.modality = proc.modality;
+        mpps_datasets.push_back(ds);
+
+        auto result = mpps_handler->on_n_create(ds);
+        E2E_ASSERT(result.has_value(),
+                    "N-CREATE for " + proc.modality + " should succeed");
+    }
+
+    // Verify all procedures active
+    auto active = mpps_handler->get_active_mpps();
+    E2E_ASSERT(active.has_value() && active->size() >= 3,
+               "Should have 3 active procedures");
+
+    // Complete procedures in reverse order (US, MR, CT)
+    for (int i = static_cast<int>(mpps_datasets.size()) - 1; i >= 0; --i) {
+        mpps_datasets[i].status = pacs_adapter::mpps_event::completed;
+        mpps_datasets[i].end_date = mpps_test_data_generator::get_today_date();
+        mpps_datasets[i].end_time =
+            mpps_test_data_generator::get_offset_time(20 + i * 10);
+        auto result = mpps_handler->on_n_set(mpps_datasets[i]);
+        E2E_ASSERT(result.has_value(),
+                    "N-SET COMPLETED for procedure " +
+                        std::to_string(i) + " should succeed");
+    }
+
+    E2E_ASSERT(completed_count == 3, "All 3 procedures should be completed");
+
+    // Verify no active procedures remain
+    auto active_after = mpps_handler->get_active_mpps();
+    E2E_ASSERT(active_after.has_value() && active_after->empty(),
+               "No active procedures should remain");
+
+    // Send all completion status updates to RIS
+    int msg_idx = 0;
+    for (const auto& proc : procedures) {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = ris_port;
+        mllp::mllp_client client(client_config);
+
+        if (client.connect().has_value()) {
+            auto orm_cm = hl7_templates::build_orm_status_update(
+                proc.patient_id, proc.patient_name,
+                "ORD_" + std::to_string(msg_idx), proc.accession,
+                proc.modality, "CM",
+                "E2E_MULTI_" + std::to_string(msg_idx));
+            auto msg = mllp::mllp_message::from_string(orm_cm);
+            (void)client.send(msg);
+            client.disconnect();
+        }
+        msg_idx++;
+    }
+
+    E2E_ASSERT(ris.messages_received() >= 3,
+               "RIS should receive all 3 completion messages");
+
+    mpps_handler->stop();
+    mwl_client.disconnect();
+    ris.stop();
+    return true;
+}
+
+// =============================================================================
+// Test: MWL-MPPS Accession Number Correlation
+// =============================================================================
+
+/**
+ * @brief Test that MWL entries and MPPS records correctly correlate
+ *        via accession number throughout the workflow
+ */
+bool test_mwl_mpps_accession_correlation() {
+    auto mwl_config = pacs_system_test_fixture::create_mwl_test_config();
+    pacs_adapter::mwl_client mwl_client(mwl_config);
+    (void)mwl_client.connect();
+
+    std::string accession = pacs_system_test_fixture::generate_unique_accession();
+    std::string patient_id = "E2E_CORR_PAT_001";
+
+    // Create MWL entry
+    auto mwl_item = mwl_test_data_generator::create_item_with_accession(accession);
+    mwl_item.patient.patient_id = patient_id;
+    (void)mwl_client.add_entry(mwl_item);
+
+    // Create MPPS with same accession
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    auto mpps_dataset = mpps_test_data_generator::create_in_progress();
+    mpps_dataset.accession_number = accession;
+    mpps_dataset.patient_id = patient_id;
+    (void)mpps_handler->on_n_create(mpps_dataset);
+
+    // Query MWL by accession
+    pacs_adapter::mwl_query_filter mwl_filter;
+    mwl_filter.accession_number = accession;
+    auto mwl_result = mwl_client.query(mwl_filter);
+    E2E_ASSERT(mwl_result.has_value() && mwl_result->items.size() == 1,
+               "Should find exactly 1 MWL entry");
+
+    // Query MPPS by accession
+    pacs_adapter::mpps_handler::mpps_query_params mpps_params;
+    mpps_params.accession_number = accession;
+    auto mpps_result = mpps_handler->query_mpps(mpps_params);
+    E2E_ASSERT(mpps_result.has_value() && mpps_result->size() >= 1,
+               "Should find MPPS record by accession");
+
+    // Verify patient ID correlation
+    E2E_ASSERT(mwl_result->items[0].patient.patient_id ==
+                   (*mpps_result)[0].patient_id,
+               "Patient ID should match between MWL and MPPS");
+
+    // Complete MPPS
+    mpps_dataset.status = pacs_adapter::mpps_event::completed;
+    mpps_dataset.end_date = mpps_test_data_generator::get_today_date();
+    mpps_dataset.end_time = mpps_test_data_generator::get_offset_time(25);
+    (void)mpps_handler->on_n_set(mpps_dataset);
+
+    // Verify completed status
+    auto final_query = mpps_handler->query_mpps(mpps_dataset.sop_instance_uid);
+    E2E_ASSERT(final_query.has_value() && final_query->has_value(),
+               "Completed MPPS should be queryable");
+    E2E_ASSERT(final_query->value().status ==
+                   pacs_adapter::mpps_event::completed,
+               "Final status should be COMPLETED");
+
+    mpps_handler->stop();
+    mwl_client.disconnect();
+    return true;
+}
+
+// =============================================================================
+// Test: RIS Failover During Workflow
+// =============================================================================
+
+/**
+ * @brief Test workflow continues when primary RIS is unavailable
+ *
+ * Validates:
+ *   1. MPPS workflow proceeds independently of RIS availability
+ *   2. Status messages fail gracefully when RIS is down
+ *   3. Status messages succeed when backup RIS is available
+ */
+bool test_workflow_with_ris_failover() {
+    uint16_t primary_port = integration_test_fixture::generate_test_port();
+    uint16_t backup_port = integration_test_fixture::generate_test_port();
+
+    // Only start backup RIS (primary is "down")
+    mock_ris_server::config backup_config;
+    backup_config.port = backup_port;
+    mock_ris_server backup_ris(backup_config);
+
+    E2E_ASSERT(backup_ris.start(), "Backup RIS should start");
+    E2E_ASSERT(
+        integration_test_fixture::wait_for(
+            [&backup_ris]() { return backup_ris.is_running(); },
+            std::chrono::milliseconds{2000}),
+        "Backup RIS should be running");
+
+    // MPPS workflow proceeds regardless of RIS
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    auto mpps_dataset = mpps_test_data_generator::create_in_progress();
+    auto create_result = mpps_handler->on_n_create(mpps_dataset);
+    E2E_ASSERT(create_result.has_value(),
+               "MPPS N-CREATE should succeed regardless of RIS");
+
+    // Try primary RIS (should fail)
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = primary_port;
+        client_config.connect_timeout = std::chrono::milliseconds{500};
+        mllp::mllp_client client(client_config);
+
+        auto connect_result = client.connect();
+        E2E_ASSERT(!connect_result.has_value(),
+                    "Primary RIS connection should fail");
+    }
+
+    // Failover: send to backup RIS
+    {
+        mllp::mllp_client_config client_config;
+        client_config.host = "localhost";
+        client_config.port = backup_port;
+        mllp::mllp_client client(client_config);
+
+        E2E_ASSERT(client.connect().has_value(),
+                    "Backup RIS connection should succeed");
+
+        auto orm_ip = hl7_templates::build_orm_status_update(
+            mpps_dataset.patient_id, mpps_dataset.patient_name,
+            "ORD_FAILOVER", mpps_dataset.accession_number,
+            "CT", "IP", "E2E_FAILOVER_001");
+        auto msg = mllp::mllp_message::from_string(orm_ip);
+        auto send_result = client.send(msg);
+        E2E_ASSERT(send_result.has_value(),
+                    "Backup RIS should receive message");
+        client.disconnect();
+    }
+
+    E2E_ASSERT(backup_ris.messages_received() >= 1,
+               "Backup RIS should receive failover message");
+
+    // Complete MPPS
+    mpps_dataset.status = pacs_adapter::mpps_event::completed;
+    mpps_dataset.end_date = mpps_test_data_generator::get_today_date();
+    mpps_dataset.end_time = mpps_test_data_generator::get_offset_time(20);
+    auto set_result = mpps_handler->on_n_set(mpps_dataset);
+    E2E_ASSERT(set_result.has_value(),
+               "MPPS completion should succeed regardless of RIS");
+
+    mpps_handler->stop();
+    backup_ris.stop();
+    return true;
+}
+
+// =============================================================================
+// Test: Workflow Error Resilience
+// =============================================================================
+
+/**
+ * @brief Test that workflow continues after individual operation failures
+ */
+bool test_workflow_error_resilience() {
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    int successful_callbacks = 0;
+    mpps_handler->set_callback(
+        [&successful_callbacks](pacs_adapter::mpps_event /*event*/,
+                                const pacs_adapter::mpps_dataset& /*dataset*/) {
+            successful_callbacks++;
+        });
+
+    // Valid procedure 1
+    auto valid1 = mpps_test_data_generator::create_in_progress();
+    auto result1 = mpps_handler->on_n_create(valid1);
+    E2E_ASSERT(result1.has_value(), "First valid N-CREATE should succeed");
+
+    // Invalid procedure (empty dataset should fail)
+    pacs_adapter::mpps_dataset invalid;
+    auto invalid_result = mpps_handler->on_n_create(invalid);
+    E2E_ASSERT(!invalid_result.has_value(),
+               "Invalid N-CREATE should fail gracefully");
+
+    // Valid procedure 2 (workflow continues)
+    auto valid2 = mpps_test_data_generator::create_in_progress();
+    auto result2 = mpps_handler->on_n_create(valid2);
+    E2E_ASSERT(result2.has_value(),
+               "Second valid N-CREATE should succeed after error");
+
+    // Complete both valid procedures
+    valid1.status = pacs_adapter::mpps_event::completed;
+    valid1.end_date = mpps_test_data_generator::get_today_date();
+    valid1.end_time = mpps_test_data_generator::get_offset_time(15);
+    (void)mpps_handler->on_n_set(valid1);
+
+    valid2.status = pacs_adapter::mpps_event::completed;
+    valid2.end_date = mpps_test_data_generator::get_today_date();
+    valid2.end_time = mpps_test_data_generator::get_offset_time(20);
+    (void)mpps_handler->on_n_set(valid2);
+
+    E2E_ASSERT(successful_callbacks == 4,
+               "Should have 4 callbacks (2 create + 2 complete)");
+
+    mpps_handler->stop();
+    return true;
+}
+
+// =============================================================================
+// Test: High-Volume Workflow
+// =============================================================================
+
+/**
+ * @brief Test high-volume workflow with multiple rapid MPPS operations and
+ *        concurrent MLLP message delivery
+ */
+bool test_high_volume_hl7_mpps_workflow() {
+    uint16_t ris_port = integration_test_fixture::generate_test_port();
+
+    mock_ris_server::config ris_config;
+    ris_config.port = ris_port;
+    mock_ris_server ris(ris_config);
+
+    E2E_ASSERT(ris.start(), "Failed to start RIS");
+    E2E_ASSERT(
+        integration_test_fixture::wait_for(
+            [&ris]() { return ris.is_running(); },
+            std::chrono::milliseconds{2000}),
+        "RIS should start");
+
+    auto mpps_config = pacs_system_test_fixture::create_mpps_test_config();
+    auto mpps_handler = pacs_adapter::mpps_handler::create(mpps_config);
+
+    mpps_handler->set_callback(
+        [](pacs_adapter::mpps_event, const pacs_adapter::mpps_dataset&) {});
+
+    const size_t num_procedures = 50;
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    // Create and complete procedures rapidly
+    for (size_t i = 0; i < num_procedures; ++i) {
+        auto ds = mpps_test_data_generator::create_in_progress();
+        (void)mpps_handler->on_n_create(ds);
+
+        ds.status = pacs_adapter::mpps_event::completed;
+        ds.end_date = mpps_test_data_generator::get_today_date();
+        ds.end_time = mpps_test_data_generator::get_offset_time(30);
+        (void)mpps_handler->on_n_set(ds);
+    }
+
+    auto end_time = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    std::cout << "  " << num_procedures << " MPPS workflows in "
+              << duration.count() << "ms" << std::endl;
+
+    E2E_ASSERT(duration.count() < 30000,
+               "Should process 50 procedures in under 30 seconds");
+
+    // Verify statistics
+    auto stats = mpps_handler->get_statistics();
+    E2E_ASSERT(stats.n_create_count >= num_procedures,
+               "Should have all N-CREATEs recorded");
+    E2E_ASSERT(stats.completed_count >= num_procedures,
+               "Should have all completions recorded");
+
+    // Send concurrent MLLP messages
+    const int msg_count = 10;
+    std::atomic<int> success_count{0};
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < msg_count; ++i) {
+        threads.emplace_back([&, i]() {
+            mllp::mllp_client_config client_config;
+            client_config.host = "localhost";
+            client_config.port = ris_port;
+            mllp::mllp_client client(client_config);
+
+            if (!client.connect().has_value()) return;
+
+            auto orm_msg = hl7_templates::build_orm_status_update(
+                "PAT_VOL" + std::to_string(i), "VOL^PATIENT",
+                "ORD_VOL" + std::to_string(i),
+                "ACC_VOL" + std::to_string(i), "CT", "CM",
+                "VOL_MSG_" + std::to_string(i));
+            auto msg = mllp::mllp_message::from_string(orm_msg);
+            if (client.send(msg).has_value()) {
+                success_count++;
+            }
+            client.disconnect();
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    E2E_ASSERT(success_count == msg_count,
+               "All " + std::to_string(msg_count) +
+                   " MLLP messages should succeed");
+
+    mpps_handler->stop();
+    ris.stop();
+    return true;
+}
+
+// =============================================================================
+// Main Test Runner
+// =============================================================================
+
+int run_all_hl7_mpps_workflow_tests() {
+    int passed = 0;
+    int failed = 0;
+
+    std::cout << "=============================================" << std::endl;
+    std::cout << "HL7 -> MWL -> MPPS -> HL7 E2E Workflow Tests" << std::endl;
+    std::cout << "Phase 5c - Issue #321" << std::endl;
+    std::cout << "=============================================" << std::endl;
+
+    std::cout << "\n--- Complete Workflow Tests ---" << std::endl;
+    RUN_E2E_TEST(test_hl7_order_to_mpps_complete_workflow);
+    RUN_E2E_TEST(test_hl7_order_cancellation_workflow);
+
+    std::cout << "\n--- Multi-Procedure Tests ---" << std::endl;
+    RUN_E2E_TEST(test_multi_procedure_concurrent_workflow);
+    RUN_E2E_TEST(test_mwl_mpps_accession_correlation);
+
+    std::cout << "\n--- Resilience Tests ---" << std::endl;
+    RUN_E2E_TEST(test_workflow_with_ris_failover);
+    RUN_E2E_TEST(test_workflow_error_resilience);
+
+    std::cout << "\n--- Performance Tests ---" << std::endl;
+    RUN_E2E_TEST(test_high_volume_hl7_mpps_workflow);
+
+    std::cout << "\n=============================================" << std::endl;
+    std::cout << "Results: " << passed << " passed, " << failed << " failed"
+              << std::endl;
+    std::cout << "Total:  " << (passed + failed) << std::endl;
+    if (passed + failed > 0) {
+        double pass_rate = (passed * 100.0) / (passed + failed);
+        std::cout << "Pass Rate: " << pass_rate << "%" << std::endl;
+    }
+    std::cout << "=============================================" << std::endl;
+
+    return failed > 0 ? 1 : 0;
+}
+
+}  // namespace pacs::bridge::e2e::test
+
+int main() {
+    return pacs::bridge::e2e::test::run_all_hl7_mpps_workflow_tests();
+}


### PR DESCRIPTION
## Summary

- Add comprehensive E2E workflow tests validating complete business scenarios (Phase 5c)
- Implement 14 tests across 2 test binaries covering HL7 and FHIR workflows
- Create `tests/e2e/` directory with dedicated CMake build configuration

### HL7 to MPPS Workflow Tests (7 tests)
| Test | Description |
|------|-------------|
| Complete IHE Workflow | ORM→MWL→MPPS N-CREATE→ORM(IP)→MPPS N-SET→ORM(CM)→ORU |
| Order Cancellation | MWL creation → MPPS start → discontinue → cancel message |
| Multi-Procedure | 3 concurrent procedures on CT/MR/US, completed in arbitrary order |
| Accession Correlation | MWL-MPPS correlation verification via accession number |
| RIS Failover | MPPS workflow continues when primary RIS is down, failover to backup |
| Error Resilience | Workflow continues after individual operation failures |
| High Volume | 50 MPPS procedures + 10 concurrent MLLP messages |

### FHIR Workflow Tests (7 tests)
| Test | Description |
|------|-------------|
| ServiceRequest → Report | Complete ServiceRequest→MWL→MPPS→DiagnosticReport pipeline |
| Patient Lookup | Patient demographics validation and MWL creation |
| DiagnosticReport Build | Comprehensive FHIR report with all required fields |
| Result Status Lifecycle | Preliminary → Final → Amended status progression |
| Multi-System Integration | End-to-end HIS+PACS+EMR workflow via MLLP |
| Incomplete Data | Validation catches incomplete study results |
| Retry Policy | Exponential backoff calculation verification |

## Test Plan
- [x] All 14 E2E tests pass locally (100% pass rate)
- [x] Build succeeds with no errors
- [x] Tests follow existing project patterns (custom framework with `INTEGRATION_TEST_ASSERT`)
- [ ] CI pipeline passes

Closes #321