### PR TITLE
fix: resolve error code range collisions across three module pairs

### DIFF
--- a/docs/api/error-codes.md
+++ b/docs/api/error-codes.md
@@ -1,7 +1,7 @@
 # Error Codes Reference
 
-> **Version:** 0.1.0.0
-> **Last Updated:** 2025-12-10
+> **Version:** 0.2.0.0
+> **Last Updated:** 2026-02-08
 
 ---
 
@@ -63,6 +63,56 @@ Where:
 | 5000-5999 | PACS | DICOM/PACS integration errors |
 | 6000-6999 | Security | Authentication and authorization errors |
 | 9000-9999 | System | Internal system errors |
+
+---
+
+## Internal Error Code Allocation (enum values)
+
+> **Note:** The `PACS-XXXX` codes above are user-facing identifiers. Internally, the
+> C++ codebase uses `enum class` types with negative integer values. This table
+> documents the internal allocation to prevent range collisions.
+> See [#344](https://github.com/kcenon/pacs_bridge/issues/344) for details.
+
+| Range | Module | Enum Type | Header |
+|-------|--------|-----------|--------|
+| -700 to -705 | Integration | `integration_error` | `integration/network_adapter.h` |
+| **-750 to -759** | **Configuration** | **`config_error`** | **`config/bridge_config.h`** |
+| -800 to -809 | Bridge Server | `bridge_server_error` | `bridge_server.h` |
+| -800 to -812 | Database | `database_error` | `integration/database_adapter.h` |
+| -850 to -863 | PACS Adapter | `pacs_error` | `integration/pacs_adapter.h` |
+| -850 to -859 | ADT Handler | `adt_error` | `protocol/hl7/adt_handler.h` |
+| -860 to -869 | ORM Handler | `orm_error` | `protocol/hl7/orm_handler.h` |
+| -870 to -878 | MWL Adapter | `mwl_adapter_error` | `integration/mwl_adapter.h` |
+| -870 to -879 | SIU Handler | `siu_error` | `protocol/hl7/siu_handler.h` |
+| **-880 to -893** | **MPPS Handler** | **`mpps_error`** | **`pacs_adapter/mpps_handler.h`** |
+| -900 to -909 | Workflow | `workflow_error` | `workflow/mpps_hl7_workflow.h` |
+| -910 to -919 | Queue | `queue_error` | `router/queue_manager.h` |
+| -920 to -925 | Cache | `cache_error` | `cache/patient_cache.h` |
+| -920 to -929 | Outbound | `outbound_error` | `router/outbound_router.h` |
+| -930 to -938 | Router | `router_error` | `router/message_router.h` |
+| -930 to -938 | DICOM-HL7 | `dicom_hl7_error` | `mapping/dicom_hl7_mapper.h` |
+| -940 to -949 | Performance | `performance_error` | `performance/performance_types.h` |
+| -950 to -958 | Access Control | `access_error` | `security/access_control.h` |
+| -950 to -967 | HL7 Protocol | `hl7_error` | `protocol/hl7/hl7_types.h` |
+| -960 to -969 | Load Testing | `load_error` | `testing/load_types.h` |
+| -960 to -969 | Validation | `validation_error` | `security/input_validator.h` |
+| -960 to -965 | Exporter | `exporter_error` | `tracing/exporter_factory.h` |
+| -970 to -979 | MLLP | `mllp_error` | `mllp/mllp_types.h` |
+| -980 to -987 | Network | `network_error` | `mllp/mllp_network_adapter.h` |
+| -980 to -985 | Health | `health_error` | `monitoring/health_types.h` |
+| -980 to -989 | MWL Client | `mwl_error` | `pacs_adapter/mwl_client.h` |
+| -990 to -999 | TLS | `tls_error` | `security/tls_types.h` |
+| -1000 to -1019 | EMR | `emr_error` | `emr/emr_types.h` |
+| -1020 to -1034 | OAuth2 | `oauth2_error` | `security/oauth2_types.h` |
+| -1040 to -1059 | Patient | `patient_error` | `emr/patient_record.h` |
+| -1060 to -1079 | Result | `result_error` | `emr/result_poster.h` |
+| -1080 to -1099 | Encounter | `encounter_error` | `emr/encounter_context.h` |
+| -1100 to -1108 | EMR Config | `emr_config_error` | `config/emr_config.h` |
+| -1100 to -1109 | EMR Adapter | `adapter_error` | `emr/emr_adapter.h` |
+| **-1120 to -1124** | **Result Tracker** | **`tracker_error`** | **`emr/result_tracker.h`** |
+
+> **Bold entries** were relocated in [#344](https://github.com/kcenon/pacs_bridge/issues/344).
+> Remaining collisions are tracked in a follow-up issue.
 
 ---
 
@@ -1031,7 +1081,10 @@ Error code range: -1080 to -1099
 ## Workflow Errors
 
 Workflow errors occur during MPPS to HL7 workflow orchestration.
-Error code range: -900 to -909
+Error code range: -900 to -909 (`workflow_error` enum)
+
+> **Note:** `config_error` previously shared this range (-900 to -909) but has been
+> relocated to -750 to -759. See [#344](https://github.com/kcenon/pacs_bridge/issues/344).
 
 ### PACS-900: Workflow Not Running
 

--- a/include/pacs/bridge/config/bridge_config.h
+++ b/include/pacs/bridge/config/bridge_config.h
@@ -38,44 +38,46 @@
 namespace pacs::bridge::config {
 
 // =============================================================================
-// Error Codes (-900 to -909)
+// Error Codes (-750 to -759)
 // =============================================================================
 
 /**
  * @brief Configuration specific error codes
  *
- * Allocated range: -900 to -909
+ * Allocated range: -750 to -759
+ * @note Relocated from -900 to -909 to resolve collision with workflow_error.
+ *       See https://github.com/kcenon/pacs_bridge/issues/344
  */
 enum class config_error : int {
     /** Configuration file not found */
-    file_not_found = -900,
+    file_not_found = -750,
 
     /** Failed to parse configuration file */
-    parse_error = -901,
+    parse_error = -751,
 
     /** Configuration validation failed */
-    validation_error = -902,
+    validation_error = -752,
 
     /** Required field is missing */
-    missing_required_field = -903,
+    missing_required_field = -753,
 
     /** Invalid value for configuration field */
-    invalid_value = -904,
+    invalid_value = -754,
 
     /** Environment variable not found */
-    env_var_not_found = -905,
+    env_var_not_found = -755,
 
     /** Invalid file format (not YAML or JSON) */
-    invalid_format = -906,
+    invalid_format = -756,
 
     /** Configuration file is empty */
-    empty_config = -907,
+    empty_config = -757,
 
     /** Circular include detected */
-    circular_include = -908,
+    circular_include = -758,
 
     /** IO error reading file */
-    io_error = -909
+    io_error = -759
 };
 
 /**

--- a/include/pacs/bridge/emr/result_tracker.h
+++ b/include/pacs/bridge/emr/result_tracker.h
@@ -26,29 +26,31 @@
 namespace pacs::bridge::emr {
 
 // =============================================================================
-// Result Tracker Error Codes (-1020 to -1029)
+// Result Tracker Error Codes (-1120 to -1124)
 // =============================================================================
 
 /**
  * @brief Result tracker specific error codes
  *
- * Allocated range: -1020 to -1029
+ * Allocated range: -1120 to -1124
+ * @note Relocated from -1020 to -1024 to resolve collision with oauth2_error.
+ *       See https://github.com/kcenon/pacs_bridge/issues/344
  */
 enum class tracker_error : int {
     /** Entry not found */
-    not_found = -1020,
+    not_found = -1120,
 
     /** Tracker is full (capacity exceeded) */
-    capacity_exceeded = -1021,
+    capacity_exceeded = -1121,
 
     /** Invalid entry data */
-    invalid_entry = -1022,
+    invalid_entry = -1122,
 
     /** Entry already exists (for unique operations) */
-    already_exists = -1023,
+    already_exists = -1123,
 
     /** Operation failed */
-    operation_failed = -1024
+    operation_failed = -1124
 };
 
 /**

--- a/include/pacs/bridge/pacs_adapter/mpps_handler.h
+++ b/include/pacs/bridge/pacs_adapter/mpps_handler.h
@@ -41,56 +41,59 @@ class mpps_adapter;
 namespace pacs::bridge::pacs_adapter {
 
 // =============================================================================
-// Error Codes (-970 to -979)
+// Error Codes (-880 to -893)
 // =============================================================================
 
 /**
  * @brief MPPS handler specific error codes
  *
- * Allocated range: -970 to -979
+ * Allocated range: -880 to -893
+ * @note Relocated from -970 to -983 to resolve collision with mllp_error
+ *       (-970 to -979) and mwl_error (-980 to -989).
+ *       See https://github.com/kcenon/pacs_bridge/issues/344
  */
 enum class mpps_error : int {
     /** Cannot connect to pacs_system MPPS SCP */
-    connection_failed = -970,
+    connection_failed = -880,
 
     /** Registration with MPPS SCP failed */
-    registration_failed = -971,
+    registration_failed = -881,
 
     /** Invalid MPPS dataset received */
-    invalid_dataset = -972,
+    invalid_dataset = -882,
 
     /** MPPS status parsing failed */
-    status_parse_failed = -973,
+    status_parse_failed = -883,
 
     /** Missing required attribute in MPPS */
-    missing_attribute = -974,
+    missing_attribute = -884,
 
     /** Callback invocation failed */
-    callback_failed = -975,
+    callback_failed = -885,
 
     /** Handler not registered */
-    not_registered = -976,
+    not_registered = -886,
 
     /** Handler already registered */
-    already_registered = -977,
+    already_registered = -887,
 
     /** Invalid MPPS SOP Instance UID */
-    invalid_sop_instance = -978,
+    invalid_sop_instance = -888,
 
     /** Unexpected MPPS operation */
-    unexpected_operation = -979,
+    unexpected_operation = -889,
 
     /** Database operation failed */
-    database_error = -980,
+    database_error = -890,
 
     /** MPPS record not found in database */
-    record_not_found = -981,
+    record_not_found = -891,
 
     /** Invalid state transition (e.g., updating final state) */
-    invalid_state_transition = -982,
+    invalid_state_transition = -892,
 
     /** Persistence is disabled */
-    persistence_disabled = -983
+    persistence_disabled = -893
 };
 
 /**

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -150,13 +150,13 @@ bool test_config_error_to_string() {
 }
 
 bool test_config_error_code_values() {
-    TEST_ASSERT(to_error_code(config_error::file_not_found) == -900,
+    TEST_ASSERT(to_error_code(config_error::file_not_found) == -750,
                 "file_not_found code");
-    TEST_ASSERT(to_error_code(config_error::parse_error) == -901,
+    TEST_ASSERT(to_error_code(config_error::parse_error) == -751,
                 "parse_error code");
-    TEST_ASSERT(to_error_code(config_error::validation_error) == -902,
+    TEST_ASSERT(to_error_code(config_error::validation_error) == -752,
                 "validation_error code");
-    TEST_ASSERT(to_error_code(config_error::io_error) == -909,
+    TEST_ASSERT(to_error_code(config_error::io_error) == -759,
                 "io_error code");
 
     return true;

--- a/tests/mpps_handler_test.cpp
+++ b/tests/mpps_handler_test.cpp
@@ -108,26 +108,26 @@ mpps_dataset create_test_mpps_dataset(
 // =============================================================================
 
 bool test_mpps_error_codes() {
-    TEST_ASSERT(to_error_code(mpps_error::connection_failed) == -970,
-                "connection_failed should be -970");
-    TEST_ASSERT(to_error_code(mpps_error::registration_failed) == -971,
-                "registration_failed should be -971");
-    TEST_ASSERT(to_error_code(mpps_error::invalid_dataset) == -972,
-                "invalid_dataset should be -972");
-    TEST_ASSERT(to_error_code(mpps_error::status_parse_failed) == -973,
-                "status_parse_failed should be -973");
-    TEST_ASSERT(to_error_code(mpps_error::missing_attribute) == -974,
-                "missing_attribute should be -974");
-    TEST_ASSERT(to_error_code(mpps_error::callback_failed) == -975,
-                "callback_failed should be -975");
-    TEST_ASSERT(to_error_code(mpps_error::not_registered) == -976,
-                "not_registered should be -976");
-    TEST_ASSERT(to_error_code(mpps_error::already_registered) == -977,
-                "already_registered should be -977");
-    TEST_ASSERT(to_error_code(mpps_error::invalid_sop_instance) == -978,
-                "invalid_sop_instance should be -978");
-    TEST_ASSERT(to_error_code(mpps_error::unexpected_operation) == -979,
-                "unexpected_operation should be -979");
+    TEST_ASSERT(to_error_code(mpps_error::connection_failed) == -880,
+                "connection_failed should be -880");
+    TEST_ASSERT(to_error_code(mpps_error::registration_failed) == -881,
+                "registration_failed should be -881");
+    TEST_ASSERT(to_error_code(mpps_error::invalid_dataset) == -882,
+                "invalid_dataset should be -882");
+    TEST_ASSERT(to_error_code(mpps_error::status_parse_failed) == -883,
+                "status_parse_failed should be -883");
+    TEST_ASSERT(to_error_code(mpps_error::missing_attribute) == -884,
+                "missing_attribute should be -884");
+    TEST_ASSERT(to_error_code(mpps_error::callback_failed) == -885,
+                "callback_failed should be -885");
+    TEST_ASSERT(to_error_code(mpps_error::not_registered) == -886,
+                "not_registered should be -886");
+    TEST_ASSERT(to_error_code(mpps_error::already_registered) == -887,
+                "already_registered should be -887");
+    TEST_ASSERT(to_error_code(mpps_error::invalid_sop_instance) == -888,
+                "invalid_sop_instance should be -888");
+    TEST_ASSERT(to_error_code(mpps_error::unexpected_operation) == -889,
+                "unexpected_operation should be -889");
 
     return true;
 }
@@ -967,14 +967,14 @@ bool test_persistence_statistics() {
  * @brief Test new error codes for persistence
  */
 bool test_persistence_error_codes() {
-    TEST_ASSERT(to_error_code(mpps_error::database_error) == -980,
-                "database_error should be -980");
-    TEST_ASSERT(to_error_code(mpps_error::record_not_found) == -981,
-                "record_not_found should be -981");
-    TEST_ASSERT(to_error_code(mpps_error::invalid_state_transition) == -982,
-                "invalid_state_transition should be -982");
-    TEST_ASSERT(to_error_code(mpps_error::persistence_disabled) == -983,
-                "persistence_disabled should be -983");
+    TEST_ASSERT(to_error_code(mpps_error::database_error) == -890,
+                "database_error should be -890");
+    TEST_ASSERT(to_error_code(mpps_error::record_not_found) == -891,
+                "record_not_found should be -891");
+    TEST_ASSERT(to_error_code(mpps_error::invalid_state_transition) == -892,
+                "invalid_state_transition should be -892");
+    TEST_ASSERT(to_error_code(mpps_error::persistence_disabled) == -893,
+                "persistence_disabled should be -893");
 
     TEST_ASSERT(std::string(to_string(mpps_error::database_error)) ==
                 "Database operation failed",


### PR DESCRIPTION
Closes #344

## Summary

- Relocated `config_error` from -900..-909 to **-750..-759** to resolve collision with `workflow_error`
- Relocated `mpps_error` from -970..-983 to **-880..-893** to resolve collision with `mllp_error` and `mwl_error`
- Relocated `tracker_error` from -1020..-1024 to **-1120..-1124** to resolve collision with `oauth2_error`
- Added comprehensive internal error code allocation table to `docs/api/error-codes.md`

## Context

Multiple `enum class` error types shared identical integer ranges. While C++ strong typing prevents compile-time issues, the overlapping values made it impossible to uniquely identify error sources from logged integer codes — critical for HIPAA audit logging and production incident analysis.

### Range Relocation Map

| Enum | Old Range | New Range | Collision Resolved |
|------|-----------|-----------|-------------------|
| `config_error` | -900 to -909 | -750 to -759 | vs `workflow_error` |
| `mpps_error` | -970 to -983 | -880 to -893 | vs `mllp_error`, `mwl_error` |
| `tracker_error` | -1020 to -1024 | -1120 to -1124 | vs `oauth2_error` |

### Additional Findings

During analysis, additional collisions were discovered beyond the 3 targeted in this issue (e.g., `adt_error` vs `pacs_error`, `router_error` vs `dicom_hl7_error`). These are documented in the new allocation table and will be addressed in a follow-up issue.

## Test Plan

- [x] `config_test` — 28/28 passed (error code value assertions updated)
- [x] `mpps_handler_test` — 33/33 passed (14 error code value assertions updated)
- [x] `result_poster_test` — 32/32 passed (includes `ResultTrackerTest` suite)
- [x] `mwl_client_test` — 37/37 passed (adjacent module, no side effects)
- [x] `mpps_hl7_workflow_test` — 28/28 passed (adjacent module, no side effects)
- [x] `oauth2_test` — 37/37 passed (adjacent module, no side effects)