### PR TITLE
docs: remove incorrect FHIR R5 claims from user-facing documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PACS Bridge enables healthcare facilities to integrate their PACS (Picture Archi
 ## Features
 
 - **HL7 v2.x Gateway** - ADT, ORM, ORU, SIU message support via MLLP
-- **FHIR R4/R5 Gateway** - RESTful API integration with modern EHR systems
+- **FHIR R4 Gateway** - RESTful API integration with modern EHR systems
 - **Modality Worklist Bridge** - MWL C-FIND to RIS/HIS query translation
 - **MPPS Notification** - Exam status propagation to RIS
 - **Flexible Routing** - Multi-gateway support with failover

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ PACS Bridge translates between HL7 v2.x/FHIR messaging protocols and DICOM servi
 | Feature | Description |
 |---------|-------------|
 | **HL7 v2.x Gateway** | ADT, ORM, ORU, SIU message support via MLLP |
-| **FHIR R4/R5 Gateway** | RESTful API integration with modern EHR systems |
+| **FHIR R4 Gateway** | RESTful API integration with modern EHR systems |
 | **Modality Worklist Bridge** | MWL C-FIND to RIS/HIS query translation |
 | **MPPS Notification** | Exam status propagation to RIS |
 | **Flexible Routing** | Multi-gateway support with failover |

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -25,7 +25,7 @@ PACS Bridge is a C++20 integration gateway that connects Hospital Information Sy
 | Feature | Description |
 |---------|-------------|
 | **HL7 v2.x Gateway** | ADT, ORM, ORU, SIU message support via MLLP |
-| **FHIR R4/R5 Gateway** | RESTful API integration with modern EHR systems |
+| **FHIR R4 Gateway** | RESTful API integration with modern EHR systems |
 | **Modality Worklist Bridge** | MWL C-FIND to RIS/HIS query translation |
 | **MPPS Notification** | Exam status propagation to RIS |
 | **Flexible Routing** | Multi-gateway support with failover |


### PR DESCRIPTION
Closes #345

## Summary
- Replaced "FHIR R4/R5 Gateway" with "FHIR R4 Gateway" in all user-facing documents
- The project supports FHIR R4 only; R5 is not implemented and not specified in PRD/SRS
- Affected files: `README.md`, `docs/index.md`, `docs/user-guide/getting-started.md`

## Why
- Claiming unsupported protocol versions misleads integration engineers evaluating the product
- Healthcare integration decisions rely on accurate conformance claims
- IHE conformance statements must be factual

## Verification
- `grep -r "R4/R5\|FHIR R5" *.md docs/` returns zero matches after this change
- PRD, SRS, SDS, and source code already correctly reference R4 only

## Test Plan
- [x] Grep confirms zero "R5" references in user-facing docs
- [x] No code changes; build unaffected