### PR TITLE
fix(integration): rename mwl_adapter to mwl_query_adapter in pacs_adapter.h

### DIFF
--- a/benchmarks/baseline_benchmark.cpp
+++ b/benchmarks/baseline_benchmark.cpp
@@ -12,8 +12,8 @@
  */
 
 // Note: This file uses pacs_adapter.h only (for MPPS/storage baseline).
-// mwl_adapter.h is NOT included here to avoid ODR conflict (both headers
-// define class mwl_adapter in the same namespace).
+// The ODR conflict between pacs_adapter.h and mwl_adapter.h has been resolved
+// by renaming pacs_adapter.h's class to mwl_query_adapter (see issue #361).
 #include "pacs/bridge/integration/database_adapter.h"
 #ifndef PACS_BRIDGE_STANDALONE_BUILD
 #include "pacs/bridge/integration/executor_adapter.h"
@@ -325,8 +325,7 @@ bool test_baseline_mpps() {
 }
 
 // Note: MWL baseline comparison is in adapter_benchmark.cpp (test_baseline_mwl)
-// because mwl_adapter.h and pacs_adapter.h both define class mwl_adapter in
-// the same namespace, causing an ODR violation if included together.
+// which uses the full CRUD mwl_adapter from mwl_adapter.h.
 
 // =============================================================================
 // Performance Targets Validation

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -170,12 +170,12 @@ executor->shutdown(true);
 
 **Sub-adapters**:
 - `get_mpps_adapter()` → `mpps_adapter` (N-CREATE, N-SET, query, get)
-- `get_mwl_adapter()` → `mwl_adapter` (query, get_item)
+- `get_mwl_adapter()` → `mwl_query_adapter` (query, get_item)
 - `get_storage_adapter()` → `storage_adapter` (store, retrieve, exists)
 
-> **Note**: The `mwl_adapter` class in `pacs_adapter.h` and `mwl_adapter.h` are
-> different types in the same namespace. Do NOT include both headers in the same
-> translation unit (ODR violation).
+> **Note**: The read-only `mwl_query_adapter` in `pacs_adapter.h` is distinct from
+> the full CRUD `mwl_adapter` in `mwl_adapter.h`. Both headers can now be safely
+> included in the same translation unit.
 
 ### mwl_adapter (Standalone)
 

--- a/include/pacs/bridge/integration/pacs_adapter.h
+++ b/include/pacs/bridge/integration/pacs_adapter.h
@@ -372,17 +372,21 @@ public:
 };
 
 // =============================================================================
-// MWL Service Adapter
+// MWL Query Adapter
 // =============================================================================
 
 /**
- * @brief Modality Worklist (MWL) service adapter interface
+ * @brief Modality Worklist (MWL) query adapter interface
  *
- * Provides abstraction for DICOM Worklist Query/Retrieve operations.
+ * Provides read-only abstraction for DICOM Worklist Query/Retrieve operations.
+ * Named mwl_query_adapter to avoid ODR collision with the full CRUD
+ * mwl_adapter defined in integration/mwl_adapter.h.
+ *
+ * @see integration/mwl_adapter.h for the full CRUD interface used by mwl_client
  */
-class mwl_adapter {
+class mwl_query_adapter {
 public:
-    virtual ~mwl_adapter() = default;
+    virtual ~mwl_query_adapter() = default;
 
     /**
      * @brief Query worklist
@@ -462,9 +466,9 @@ public:
     [[nodiscard]] virtual std::shared_ptr<mpps_adapter> get_mpps_adapter() = 0;
 
     /**
-     * @brief Get MWL service adapter
+     * @brief Get MWL query adapter
      */
-    [[nodiscard]] virtual std::shared_ptr<mwl_adapter> get_mwl_adapter() = 0;
+    [[nodiscard]] virtual std::shared_ptr<mwl_query_adapter> get_mwl_adapter() = 0;
 
     /**
      * @brief Get storage service adapter

--- a/src/integration/pacs_adapter.cpp
+++ b/src/integration/pacs_adapter.cpp
@@ -221,15 +221,15 @@ private:
 };
 
 // =============================================================================
-// Stub MWL Adapter
+// Stub MWL Query Adapter
 // =============================================================================
 
 /**
- * @brief Stub implementation of MWL adapter (standalone mode)
+ * @brief Stub implementation of MWL query adapter (standalone mode)
  *
  * Provides no-op implementations for testing and standalone usage.
  */
-class stub_mwl_adapter : public mwl_adapter {
+class stub_mwl_query_adapter : public mwl_query_adapter {
 public:
     std::expected<std::vector<mwl_item>, pacs_error> query_mwl(
         const mwl_query_params& params) override {
@@ -296,7 +296,7 @@ public:
     explicit stub_pacs_adapter(const pacs_config& config)
         : config_(config)
         , mpps_adapter_(std::make_shared<stub_mpps_adapter>())
-        , mwl_adapter_(std::make_shared<stub_mwl_adapter>())
+        , mwl_adapter_(std::make_shared<stub_mwl_query_adapter>())
         , storage_adapter_(std::make_shared<stub_storage_adapter>())
         , connected_(false) {}
 
@@ -304,7 +304,7 @@ public:
         return mpps_adapter_;
     }
 
-    std::shared_ptr<mwl_adapter> get_mwl_adapter() override {
+    std::shared_ptr<mwl_query_adapter> get_mwl_adapter() override {
         return mwl_adapter_;
     }
 
@@ -335,7 +335,7 @@ public:
 private:
     pacs_config config_;
     std::shared_ptr<stub_mpps_adapter> mpps_adapter_;
-    std::shared_ptr<stub_mwl_adapter> mwl_adapter_;
+    std::shared_ptr<stub_mwl_query_adapter> mwl_adapter_;
     std::shared_ptr<stub_storage_adapter> storage_adapter_;
     bool connected_;
 };
@@ -685,18 +685,18 @@ private:
 };
 
 // =============================================================================
-// pacs_system MWL Adapter
+// pacs_system MWL Query Adapter
 // =============================================================================
 
 /**
- * @brief MWL adapter backed by pacs_system index_database
+ * @brief MWL query adapter backed by pacs_system index_database
  *
  * Provides worklist query operations through pacs_system's index database.
  * For the full MWL adapter with add/update/delete, see mwl_adapter.cpp.
  */
-class pacs_system_mwl_adapter : public mwl_adapter {
+class pacs_system_mwl_query_adapter : public mwl_query_adapter {
 public:
-    explicit pacs_system_mwl_adapter(
+    explicit pacs_system_mwl_query_adapter(
         std::shared_ptr<pacs::storage::index_database> db)
         : db_(std::move(db)) {}
 
@@ -843,7 +843,7 @@ public:
         std::shared_ptr<pacs::storage::index_database> db)
         : db_(std::move(db))
         , mpps_adapter_(std::make_shared<pacs_system_mpps_adapter>(db_))
-        , mwl_adapter_(std::make_shared<pacs_system_mwl_adapter>(db_))
+        , mwl_adapter_(std::make_shared<pacs_system_mwl_query_adapter>(db_))
         , storage_adapter_(std::make_shared<pacs_system_storage_adapter>(db_))
         , connected_(false) {}
 
@@ -851,7 +851,7 @@ public:
         return mpps_adapter_;
     }
 
-    std::shared_ptr<mwl_adapter> get_mwl_adapter() override {
+    std::shared_ptr<mwl_query_adapter> get_mwl_adapter() override {
         return mwl_adapter_;
     }
 
@@ -882,7 +882,7 @@ public:
 private:
     std::shared_ptr<pacs::storage::index_database> db_;
     std::shared_ptr<pacs_system_mpps_adapter> mpps_adapter_;
-    std::shared_ptr<pacs_system_mwl_adapter> mwl_adapter_;
+    std::shared_ptr<pacs_system_mwl_query_adapter> mwl_adapter_;
     std::shared_ptr<pacs_system_storage_adapter> storage_adapter_;
     bool connected_;
 };


### PR DESCRIPTION
Closes #361

## Summary

- Renamed the read-only `mwl_adapter` class in `pacs_adapter.h` to `mwl_query_adapter` to resolve an ODR (One Definition Rule) violation
- Both `pacs_adapter.h` and `mwl_adapter.h` can now be safely included in the same translation unit
- Updated all implementations (`stub_mwl_query_adapter`, `pacs_system_mwl_query_adapter`), benchmark comments, and documentation

## Changes

| File | Change |
|------|--------|
| `pacs_adapter.h` | `class mwl_adapter` → `class mwl_query_adapter` with updated docstring |
| `pacs_adapter.cpp` | `stub_mwl_adapter` → `stub_mwl_query_adapter`, `pacs_system_mwl_adapter` → `pacs_system_mwl_query_adapter` |
| `baseline_benchmark.cpp` | Updated ODR workaround comments (collision is now resolved) |
| `integration_guide.md` | Updated sub-adapter type name and ODR note |

## Test Plan

- [x] `pacs_adapter_test` — 39/39 passed
- [x] `standalone_mode_test` (Pacs/Mwl/SubAdapter filters) — 11/11 passed
- [x] Full build succeeds (90/90 targets, standalone mode)