### PR TITLE
fix(integration): add path validation and fallback to create_mwl_adapter() factory

### DIFF
--- a/src/integration/mwl_adapter.cpp
+++ b/src/integration/mwl_adapter.cpp
@@ -752,6 +752,15 @@ public:
         return "pacs_system";
     }
 
+    /**
+     * @brief Check if the underlying database was successfully opened
+     *
+     * @return true if database is available and operational
+     */
+    [[nodiscard]] bool is_available() const noexcept {
+        return db_ != nullptr && db_->is_open();
+    }
+
 private:
     std::unique_ptr<pacs::storage::index_database> db_;
 };
@@ -765,11 +774,20 @@ private:
 std::shared_ptr<mwl_adapter>
 create_mwl_adapter(const std::string& database_path) {
 #ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
-    return std::make_shared<pacs_mwl_adapter>(database_path);
+    // When pacs_system is available and database_path is configured,
+    // create a pacs_system-backed adapter for persistent MWL storage.
+    if (!database_path.empty()) {
+        auto adapter = std::make_shared<pacs_mwl_adapter>(database_path);
+        if (adapter->is_available()) {
+            return adapter;
+        }
+        // Database open failed - fall through to memory adapter
+    }
 #else
     (void)database_path;  // Unused in standalone mode
-    return std::make_shared<memory_mwl_adapter>();
 #endif
+    // Fallback: in-memory adapter for testing and standalone mode
+    return std::make_shared<memory_mwl_adapter>();
 }
 
 }  // namespace pacs::bridge::integration

--- a/tests/integration/standalone_mode_test.cpp
+++ b/tests/integration/standalone_mode_test.cpp
@@ -19,6 +19,7 @@
 #include "test_utilities.h"
 
 #include "pacs/bridge/integration/database_adapter.h"
+#include "pacs/bridge/integration/mwl_adapter.h"
 #include "pacs/bridge/integration/pacs_adapter.h"
 #include "pacs/bridge/mllp/mllp_network_adapter.h"
 
@@ -436,6 +437,48 @@ TEST_F(StandaloneMllpTest, SessionStatsDefaultValues) {
     EXPECT_EQ(stats.bytes_sent, 0u);
     EXPECT_EQ(stats.messages_received, 0u);
     EXPECT_EQ(stats.messages_sent, 0u);
+}
+
+// =============================================================================
+// MWL Adapter Factory Fallback Tests
+// =============================================================================
+
+class MwlAdapterFactoryTest : public Test {};
+
+TEST_F(MwlAdapterFactoryTest, EmptyPathReturnsMemoryAdapter) {
+    auto adapter = create_mwl_adapter("");
+    ASSERT_NE(adapter, nullptr);
+    EXPECT_STREQ(adapter->adapter_type(), "memory");
+}
+
+TEST_F(MwlAdapterFactoryTest, DefaultPathReturnsMemoryAdapter) {
+    auto adapter = create_mwl_adapter();
+    ASSERT_NE(adapter, nullptr);
+    EXPECT_STREQ(adapter->adapter_type(), "memory");
+}
+
+TEST_F(MwlAdapterFactoryTest, NonexistentPathReturnsMemoryAdapter) {
+    auto adapter = create_mwl_adapter("/nonexistent/path/to/db.sqlite");
+    ASSERT_NE(adapter, nullptr);
+    EXPECT_STREQ(adapter->adapter_type(), "memory");
+}
+
+TEST_F(MwlAdapterFactoryTest, MemoryAdapterIsFunctional) {
+    auto adapter = create_mwl_adapter("");
+    ASSERT_NE(adapter, nullptr);
+
+    // Verify the adapter is operational
+    mapping::mwl_item item;
+    item.imaging_service_request.accession_number = "ACC_FACTORY_001";
+    item.patient.patient_id = "PAT001";
+    item.patient.patient_name = "DOE^JOHN";
+
+    auto add_result = adapter->add_item(item);
+    EXPECT_TRUE(add_result.has_value());
+
+    auto get_result = adapter->get_item("ACC_FACTORY_001");
+    ASSERT_TRUE(get_result.has_value());
+    EXPECT_EQ(get_result->patient.patient_id, "PAT001");
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #362

## Summary
- Add empty path check and database availability validation to `create_mwl_adapter()` factory, consistent with the existing `create_pacs_adapter()` pattern
- Add `is_available()` method to `pacs_mwl_adapter` for checking database health after construction
- When the database path is empty or the database fails to open, factory falls back to `memory_mwl_adapter` instead of creating a broken `pacs_mwl_adapter`
- Add 4 unit tests verifying factory fallback behavior

## Changes

### `src/integration/mwl_adapter.cpp`
- **`pacs_mwl_adapter::is_available()`**: New method checking whether the underlying `index_database` was successfully opened
- **`create_mwl_adapter()`**: Add empty path guard and `is_available()` check before returning `pacs_mwl_adapter`, falling back to `memory_mwl_adapter` on failure (matches `create_pacs_adapter()` pattern)

### `tests/integration/standalone_mode_test.cpp`
- **`MwlAdapterFactoryTest`**: 4 new tests covering empty path, default path, nonexistent path, and functional verification of the fallback adapter

## Test plan
- [x] `MwlAdapterFactoryTest.EmptyPathReturnsMemoryAdapter` — verifies `create_mwl_adapter("")` returns memory adapter
- [x] `MwlAdapterFactoryTest.DefaultPathReturnsMemoryAdapter` — verifies `create_mwl_adapter()` (default arg) returns memory adapter
- [x] `MwlAdapterFactoryTest.NonexistentPathReturnsMemoryAdapter` — verifies invalid path falls back to memory adapter
- [x] `MwlAdapterFactoryTest.MemoryAdapterIsFunctional` — verifies fallback adapter supports add/get operations
- [x] All existing `pacs_adapter_test` (39/39), `standalone_mode_test` (28/28), `mwl_client_test` (37/37) pass