### PR TITLE
fix(integration): add is_available() to mwl_adapter interface and log init failures

### DIFF
--- a/include/pacs/bridge/integration/mwl_adapter.h
+++ b/include/pacs/bridge/integration/mwl_adapter.h
@@ -224,6 +224,17 @@ public:
     delete_items_before(std::string_view before_date) = 0;
 
     /**
+     * @brief Check if the adapter is available and operational
+     *
+     * For memory adapters, always returns true. For database-backed
+     * adapters, returns true only if the underlying database was
+     * successfully opened and is accessible.
+     *
+     * @return true if the adapter is ready for operations
+     */
+    [[nodiscard]] virtual bool is_available() const noexcept { return true; }
+
+    /**
      * @brief Get adapter type name (for debugging)
      *
      * @return Adapter type name (e.g., "memory", "pacs_system")

--- a/src/integration/mwl_adapter.cpp
+++ b/src/integration/mwl_adapter.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <iostream>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -560,7 +561,9 @@ public:
     explicit pacs_mwl_adapter(const std::string& database_path) {
         auto db_result = pacs::storage::index_database::open(database_path);
         if (db_result.is_err()) {
-            // Database failed to open - will return errors on all operations
+            std::cerr << "pacs_mwl_adapter: failed to open database '"
+                      << database_path
+                      << "' - adapter will be non-functional" << std::endl;
             return;
         }
         db_ = std::move(db_result.value());
@@ -752,12 +755,7 @@ public:
         return "pacs_system";
     }
 
-    /**
-     * @brief Check if the underlying database was successfully opened
-     *
-     * @return true if database is available and operational
-     */
-    [[nodiscard]] bool is_available() const noexcept {
+    [[nodiscard]] bool is_available() const noexcept override {
         return db_ != nullptr && db_->is_open();
     }
 
@@ -781,7 +779,8 @@ create_mwl_adapter(const std::string& database_path) {
         if (adapter->is_available()) {
             return adapter;
         }
-        // Database open failed - fall through to memory adapter
+        std::cerr << "create_mwl_adapter: database unavailable, "
+                     "falling back to in-memory adapter" << std::endl;
     }
 #else
     (void)database_path;  // Unused in standalone mode

--- a/tests/integration/standalone_mode_test.cpp
+++ b/tests/integration/standalone_mode_test.cpp
@@ -463,6 +463,20 @@ TEST_F(MwlAdapterFactoryTest, NonexistentPathReturnsMemoryAdapter) {
     EXPECT_STREQ(adapter->adapter_type(), "memory");
 }
 
+TEST_F(MwlAdapterFactoryTest, MemoryAdapterIsAvailable) {
+    auto adapter = create_mwl_adapter("");
+    ASSERT_NE(adapter, nullptr);
+    EXPECT_TRUE(adapter->is_available());
+}
+
+TEST_F(MwlAdapterFactoryTest, NonexistentPathAdapterIsAvailable) {
+    // Even with a nonexistent path, factory falls back to memory adapter
+    // which should report as available
+    auto adapter = create_mwl_adapter("/nonexistent/path/to/db.sqlite");
+    ASSERT_NE(adapter, nullptr);
+    EXPECT_TRUE(adapter->is_available());
+}
+
 TEST_F(MwlAdapterFactoryTest, MemoryAdapterIsFunctional) {
     auto adapter = create_mwl_adapter("");
     ASSERT_NE(adapter, nullptr);


### PR DESCRIPTION
Closes #363

## Summary
- Promote `is_available()` from `pacs_mwl_adapter` implementation detail to the `mwl_adapter` base interface, enabling callers to query adapter health before operations
- Add `std::cerr` warnings when database initialization fails in `pacs_mwl_adapter` constructor and when the factory falls back to in-memory adapter
- Add 2 unit tests verifying `is_available()` behavior through the base interface

## Changes

### `include/pacs/bridge/integration/mwl_adapter.h`
- **`mwl_adapter::is_available()`**: New virtual method with default `true` return; database-backed adapters override to check DB state

### `src/integration/mwl_adapter.cpp`
- **`pacs_mwl_adapter` constructor**: Add `std::cerr` warning when `index_database::open()` fails, identifying the database path
- **`pacs_mwl_adapter::is_available()`**: Add `override` specifier to match base class virtual
- **`create_mwl_adapter()` factory**: Add `std::cerr` fallback warning when DB is unavailable

### `tests/integration/standalone_mode_test.cpp`
- **`MwlAdapterFactoryTest.MemoryAdapterIsAvailable`**: Verify memory adapter reports available
- **`MwlAdapterFactoryTest.NonexistentPathAdapterIsAvailable`**: Verify fallback adapter reports available

## Test plan
- [x] `MwlAdapterFactoryTest.MemoryAdapterIsAvailable` — memory adapter `is_available()` returns true
- [x] `MwlAdapterFactoryTest.NonexistentPathAdapterIsAvailable` — fallback adapter `is_available()` returns true
- [x] All existing `standalone_mode_test` (30/30), `pacs_adapter_test` (39/39), `mwl_client_test` (37/37) pass