### PR TITLE
fix(integration): implement full field update in pacs_mwl_adapter::update_item()

### DIFF
--- a/src/integration/mwl_adapter.cpp
+++ b/src/integration/mwl_adapter.cpp
@@ -470,6 +470,44 @@ from_worklist_item(const pacs::storage::worklist_item& wl) {
     return item;
 }
 
+// Merge non-empty fields from updates into existing worklist_item
+[[nodiscard]] pacs::storage::worklist_item
+merge_worklist_item(const pacs::storage::worklist_item& existing,
+                    const pacs::storage::worklist_item& updates) {
+    pacs::storage::worklist_item merged = existing;
+
+    // Patient information
+    if (!updates.patient_id.empty()) merged.patient_id = updates.patient_id;
+    if (!updates.patient_name.empty()) merged.patient_name = updates.patient_name;
+    if (!updates.birth_date.empty()) merged.birth_date = updates.birth_date;
+    if (!updates.sex.empty()) merged.sex = updates.sex;
+
+    // Requested procedure
+    if (!updates.requested_proc_id.empty())
+        merged.requested_proc_id = updates.requested_proc_id;
+    if (!updates.study_uid.empty()) merged.study_uid = updates.study_uid;
+    if (!updates.referring_phys.empty())
+        merged.referring_phys = updates.referring_phys;
+    if (!updates.referring_phys_id.empty())
+        merged.referring_phys_id = updates.referring_phys_id;
+
+    // Scheduled procedure step
+    if (!updates.station_ae.empty()) merged.station_ae = updates.station_ae;
+    if (!updates.station_name.empty())
+        merged.station_name = updates.station_name;
+    if (!updates.modality.empty()) merged.modality = updates.modality;
+    if (!updates.procedure_desc.empty())
+        merged.procedure_desc = updates.procedure_desc;
+    if (!updates.step_status.empty())
+        merged.step_status = updates.step_status;
+    if (!updates.scheduled_datetime.empty())
+        merged.scheduled_datetime = updates.scheduled_datetime;
+    if (!updates.protocol_code.empty())
+        merged.protocol_code = updates.protocol_code;
+
+    return merged;
+}
+
 // Convert mwl_query_filter to pacs_system worklist_query
 [[nodiscard]] pacs::storage::worklist_query
 to_worklist_query(const mwl_query_filter& filter) {
@@ -620,18 +658,20 @@ public:
 
         const auto& existing_wl = query_result.value()[0];
 
-        // Convert updated item
-        auto wl_item = to_worklist_item(item);
+        // Merge non-empty update fields into existing record
+        auto wl_updates = to_worklist_item(item);
+        auto merged = merge_worklist_item(existing_wl, wl_updates);
 
-        // Update status
-        std::string new_status = wl_item.step_status.empty()
-                                     ? existing_wl.step_status
-                                     : wl_item.step_status;
+        // index_database only provides update_worklist_status() for
+        // status-only updates. To update all fields, delete and re-add.
+        auto delete_result = db_->delete_worklist_item(
+            existing_wl.step_id, std::string(accession_number));
+        if (delete_result.is_err()) {
+            return std::unexpected(mwl_adapter_error::update_failed);
+        }
 
-        auto update_result = db_->update_worklist_status(
-            existing_wl.step_id, std::string(accession_number), new_status);
-
-        if (update_result.is_err()) {
+        auto add_result = db_->add_worklist_item(merged);
+        if (add_result.is_err()) {
             return std::unexpected(mwl_adapter_error::update_failed);
         }
 

--- a/tests/integration/standalone_mode_test.cpp
+++ b/tests/integration/standalone_mode_test.cpp
@@ -495,6 +495,62 @@ TEST_F(MwlAdapterFactoryTest, MemoryAdapterIsFunctional) {
     EXPECT_EQ(get_result->patient.patient_id, "PAT001");
 }
 
+TEST_F(MwlAdapterFactoryTest, UpdateItemUpdatesAllFields) {
+    auto adapter = create_mwl_adapter("");
+    ASSERT_NE(adapter, nullptr);
+
+    // Add initial item with all fields populated
+    mapping::mwl_item item;
+    item.imaging_service_request.accession_number = "ACC_UPD_001";
+    item.patient.patient_id = "PAT001";
+    item.patient.patient_name = "DOE^JOHN";
+    item.patient.patient_birth_date = "19800101";
+    item.patient.patient_sex = "M";
+    item.requested_procedure.referring_physician_name = "SMITH^DR";
+
+    mapping::dicom_scheduled_procedure_step sps;
+    sps.scheduled_step_id = "SPS001";
+    sps.modality = "CT";
+    sps.scheduled_station_ae_title = "CT1";
+    sps.scheduled_start_date = "20260301";
+    sps.scheduled_start_time = "090000";
+    item.scheduled_steps.push_back(sps);
+
+    auto add_result = adapter->add_item(item);
+    ASSERT_TRUE(add_result.has_value());
+
+    // Update multiple fields (not just status)
+    mapping::mwl_item updates;
+    updates.imaging_service_request.accession_number = "ACC_UPD_001";
+    updates.patient.patient_name = "DOE^JANE";
+    updates.requested_procedure.referring_physician_name = "JONES^DR";
+
+    mapping::dicom_scheduled_procedure_step sps_update;
+    sps_update.modality = "MR";
+    sps_update.scheduled_start_date = "20260315";
+    sps_update.scheduled_start_time = "140000";
+    updates.scheduled_steps.push_back(sps_update);
+
+    auto update_result = adapter->update_item("ACC_UPD_001", updates);
+    ASSERT_TRUE(update_result.has_value());
+
+    // Verify ALL updated fields are reflected
+    auto get_result = adapter->get_item("ACC_UPD_001");
+    ASSERT_TRUE(get_result.has_value());
+    EXPECT_EQ(get_result->patient.patient_name, "DOE^JANE");
+    EXPECT_EQ(get_result->patient.patient_id, "PAT001");  // Unchanged
+    EXPECT_EQ(get_result->patient.patient_sex, "M");       // Unchanged
+    EXPECT_EQ(get_result->requested_procedure.referring_physician_name,
+              "JONES^DR");
+
+    ASSERT_FALSE(get_result->scheduled_steps.empty());
+    EXPECT_EQ(get_result->scheduled_steps[0].modality, "MR");
+    EXPECT_EQ(get_result->scheduled_steps[0].scheduled_start_date, "20260315");
+    EXPECT_EQ(get_result->scheduled_steps[0].scheduled_start_time, "140000");
+    EXPECT_EQ(get_result->scheduled_steps[0].scheduled_station_ae_title,
+              "CT1");  // Unchanged
+}
+
 // =============================================================================
 // Cross-Adapter Resource Cleanup Tests
 // =============================================================================


### PR DESCRIPTION
Closes #364

## Summary
- Replace status-only `update_worklist_status()` with delete-then-add approach using new `merge_worklist_item()` helper
- All non-empty update fields are now applied (patient info, scheduled datetime, modality, etc.), not just step status
- Behavior is now consistent between `pacs_mwl_adapter` and `memory_mwl_adapter`
- Add comprehensive field-level update test

## Changes

### `src/integration/mwl_adapter.cpp`
- **`merge_worklist_item()`**: New helper that merges non-empty fields from an update `worklist_item` into an existing record, mirroring `memory_mwl_adapter::update_fields()` semantics
- **`pacs_mwl_adapter::update_item()`**: Replace `db_->update_worklist_status()` (status-only) with `db_->delete_worklist_item()` + `db_->add_worklist_item(merged)` for full field update

### `tests/integration/standalone_mode_test.cpp`
- **`MwlAdapterFactoryTest.UpdateItemUpdatesAllFields`**: Verifies that `update_item()` updates patient name, referring physician, modality, scheduled date/time while preserving unchanged fields

## Why delete-then-add?
The `pacs::storage::index_database` API only provides `update_worklist_status()` for status-only updates. There is no `update_worklist_item()` method for full record updates. The delete-then-add approach achieves the same result using available API methods.

## Test plan
- [x] `MwlAdapterFactoryTest.UpdateItemUpdatesAllFields` — verifies multi-field update with selective preservation
- [x] All existing `standalone_mode_test` (31/31), `pacs_adapter_test` (39/39), `mwl_client_test` (37/37) pass