### PR TITLE
refactor(integration): remove unused MWL types from pacs_adapter

### DIFF
--- a/benchmarks/baseline_benchmark.cpp
+++ b/benchmarks/baseline_benchmark.cpp
@@ -6,18 +6,16 @@
  * - Database: direct sqlite3_exec() vs. database_adapter->execute()
  * - Thread: std::async vs. simple_executor->execute()
  * - MPPS: std::unordered_map vs. stub_mpps_adapter
- * - MWL: std::unordered_map + filter vs. memory_mwl_adapter
+ * - MWL: memory_mwl_adapter (from mwl_adapter.h)
  *
  * @see https://github.com/kcenon/pacs_bridge/issues/322
  */
 
-// Note: This file uses pacs_adapter.h only (for MPPS/storage baseline).
-// The ODR conflict between pacs_adapter.h and mwl_adapter.h has been resolved
-// by renaming pacs_adapter.h's class to mwl_query_adapter (see issue #361).
 #include "pacs/bridge/integration/database_adapter.h"
 #ifndef PACS_BRIDGE_STANDALONE_BUILD
 #include "pacs/bridge/integration/executor_adapter.h"
 #endif
+#include "pacs/bridge/integration/mwl_adapter.h"
 #include "pacs/bridge/integration/pacs_adapter.h"
 #include "pacs/bridge/performance/benchmark_runner.h"
 #include "pacs/bridge/performance/performance_types.h"
@@ -353,17 +351,16 @@ bool test_performance_targets() {
               << performance_targets::MAX_MEMORY_BASELINE_MB << " MB"
               << std::endl;
 
-    // Validate MWL latency target using PACS adapter's MWL sub-adapter
-    auto pacs = integration::create_pacs_adapter({});
-    auto mwl = pacs->get_mwl_adapter();
-    TEST_ASSERT(mwl != nullptr, "MWL sub-adapter should be available");
+    // Validate MWL latency target using mwl_adapter
+    auto mwl = integration::create_mwl_adapter("");
+    TEST_ASSERT(mwl != nullptr, "MWL adapter should be available");
 
     auto mwl_latency = benchmark_with_warmup(
         [&, idx = 0]() mutable {
-            integration::mwl_query_params params;
-            params.patient_id = "TGT" + std::to_string(idx++ % 100);
-            params.modality = "CT";
-            (void)mwl->query_mwl(params);
+            integration::mwl_query_filter filter;
+            filter.patient_id = "TGT" + std::to_string(idx++ % 100);
+            filter.modality = "CT";
+            (void)mwl->query_items(filter);
         },
         50, 1000);
 

--- a/docs/api/error-codes.md
+++ b/docs/api/error-codes.md
@@ -216,7 +216,6 @@ collisions.
 | -858 | `validation_failed` | Validation failed | Review data format |
 | -859 | `mpps_create_failed` | MPPS N-CREATE failed | Check PACS MPPS configuration |
 | -860 | `mpps_update_failed` | MPPS N-SET failed | Verify MPPS state |
-| -861 | `mwl_query_failed` | MWL query failed | Check MWL SCP configuration |
 | -862 | `storage_failed` | DICOM storage failed | Check disk space and permissions |
 | -863 | `invalid_sop_uid` | Invalid SOP Instance UID | Validate UID format |
 

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -47,7 +47,7 @@ int result = future.get();  // 42
 pool->shutdown(true);
 ```
 
-### PACS Adapter (MPPS / MWL / Storage)
+### PACS Adapter (MPPS / Storage)
 
 ```cpp
 #include "pacs/bridge/integration/pacs_adapter.h"
@@ -55,7 +55,6 @@ using namespace pacs::bridge::integration;
 
 auto pacs = create_pacs_adapter({});
 auto mpps = pacs->get_mpps_adapter();
-auto mwl  = pacs->get_mwl_adapter();
 
 // Create MPPS record
 mpps_record record;
@@ -159,7 +158,7 @@ executor->shutdown(true);
 
 **Priority Levels**: `task_priority::low`, `normal`, `high`, `critical`
 
-### pacs_adapter (MPPS + MWL + Storage)
+### pacs_adapter (MPPS + Storage)
 
 | Item | Detail |
 |------|--------|
@@ -170,12 +169,9 @@ executor->shutdown(true);
 
 **Sub-adapters**:
 - `get_mpps_adapter()` → `mpps_adapter` (N-CREATE, N-SET, query, get)
-- `get_mwl_adapter()` → `mwl_query_adapter` (query, get_item)
 - `get_storage_adapter()` → `storage_adapter` (store, retrieve, exists)
 
-> **Note**: The read-only `mwl_query_adapter` in `pacs_adapter.h` is distinct from
-> the full CRUD `mwl_adapter` in `mwl_adapter.h`. Both headers can now be safely
-> included in the same translation unit.
+> **Note**: For MWL operations, use the full CRUD `mwl_adapter` from `mwl_adapter.h`.
 
 ### mwl_adapter (Standalone)
 

--- a/include/pacs/bridge/integration/pacs_adapter.h
+++ b/include/pacs/bridge/integration/pacs_adapter.h
@@ -7,8 +7,9 @@
  *
  * Provides adapters that abstract DICOM operations and enable integration
  * with pacs_system while maintaining standalone capability. This adapter
- * consolidates PACS-related functionality scattered across multiple files
- * (mpps_handler.cpp, mwl_client.cpp) into a consistent interface.
+ * provides MPPS and storage services through a consistent interface.
+ *
+ * @note MWL operations use the full CRUD mwl_adapter from mwl_adapter.h
  *
  * @see https://github.com/kcenon/pacs_bridge/issues/283
  * @see https://github.com/kcenon/pacs_bridge/issues/273
@@ -18,7 +19,6 @@
 #include <chrono>
 #include <cstdint>
 #include <expected>
-#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -70,9 +70,6 @@ enum class pacs_error : int {
 
     /** MPPS N-SET failed */
     mpps_update_failed = -860,
-
-    /** MWL query failed */
-    mwl_query_failed = -861,
 
     /** DICOM storage failed */
     storage_failed = -862,
@@ -221,51 +218,6 @@ struct mpps_record {
 };
 
 // =============================================================================
-// MWL Item Abstraction
-// =============================================================================
-
-/**
- * @brief Modality Worklist (MWL) item
- *
- * Represents a worklist item from a DICOM Worklist query.
- */
-struct mwl_item {
-    /** Accession Number */
-    std::string accession_number;
-
-    /** Scheduled Procedure Step ID */
-    std::string scheduled_procedure_step_id;
-
-    /** Requested Procedure ID */
-    std::string requested_procedure_id;
-
-    /** Scheduled Station AE Title */
-    std::string scheduled_station_ae_title;
-
-    /** Scheduled Procedure Step Start Date/Time */
-    std::chrono::system_clock::time_point scheduled_datetime;
-
-    /** Modality */
-    std::string modality;
-
-    /** Patient ID */
-    std::string patient_id;
-
-    /** Patient Name */
-    std::string patient_name;
-
-    /** Study Instance UID */
-    std::string study_instance_uid;
-
-    /**
-     * @brief Validate MWL item fields
-     *
-     * @return true if all required fields are present and valid
-     */
-    [[nodiscard]] bool is_valid() const;
-};
-
-// =============================================================================
 // Query Parameters
 // =============================================================================
 
@@ -296,26 +248,6 @@ struct mpps_query_params {
 
     /** Start datetime range (to) */
     std::optional<std::chrono::system_clock::time_point> to_datetime;
-
-    /** Maximum number of results */
-    std::size_t max_results = 100;
-};
-
-/**
- * @brief Query parameters for MWL items
- */
-struct mwl_query_params {
-    /** Patient ID filter (optional) */
-    std::optional<std::string> patient_id;
-
-    /** Accession Number filter (optional) */
-    std::optional<std::string> accession_number;
-
-    /** Modality filter (optional) */
-    std::optional<std::string> modality;
-
-    /** Scheduled date filter (optional) */
-    std::optional<std::chrono::system_clock::time_point> scheduled_date;
 
     /** Maximum number of results */
     std::size_t max_results = 100;
@@ -372,42 +304,6 @@ public:
 };
 
 // =============================================================================
-// MWL Query Adapter
-// =============================================================================
-
-/**
- * @brief Modality Worklist (MWL) query adapter interface
- *
- * Provides read-only abstraction for DICOM Worklist Query/Retrieve operations.
- * Named mwl_query_adapter to avoid ODR collision with the full CRUD
- * mwl_adapter defined in integration/mwl_adapter.h.
- *
- * @see integration/mwl_adapter.h for the full CRUD interface used by mwl_client
- */
-class mwl_query_adapter {
-public:
-    virtual ~mwl_query_adapter() = default;
-
-    /**
-     * @brief Query worklist
-     *
-     * @param params Query parameters
-     * @return Vector of matching MWL items or error
-     */
-    [[nodiscard]] virtual std::expected<std::vector<mwl_item>, pacs_error>
-        query_mwl(const mwl_query_params& params) = 0;
-
-    /**
-     * @brief Get single MWL item by accession number
-     *
-     * @param accession_number Accession Number
-     * @return MWL item or error
-     */
-    [[nodiscard]] virtual std::expected<mwl_item, pacs_error>
-        get_mwl_item(std::string_view accession_number) = 0;
-};
-
-// =============================================================================
 // Storage Service Adapter
 // =============================================================================
 
@@ -454,7 +350,8 @@ public:
 /**
  * @brief Combined PACS adapter interface
  *
- * Provides unified access to all PACS services (MPPS, MWL, Storage).
+ * Provides unified access to PACS services (MPPS, Storage).
+ * For MWL operations, use mwl_adapter from mwl_adapter.h.
  */
 class pacs_adapter {
 public:
@@ -464,11 +361,6 @@ public:
      * @brief Get MPPS service adapter
      */
     [[nodiscard]] virtual std::shared_ptr<mpps_adapter> get_mpps_adapter() = 0;
-
-    /**
-     * @brief Get MWL query adapter
-     */
-    [[nodiscard]] virtual std::shared_ptr<mwl_query_adapter> get_mwl_adapter() = 0;
 
     /**
      * @brief Get storage service adapter

--- a/src/integration/pacs_adapter.cpp
+++ b/src/integration/pacs_adapter.cpp
@@ -43,8 +43,6 @@ std::string_view to_string(pacs_error error) noexcept {
             return "MPPS N-CREATE failed";
         case pacs_error::mpps_update_failed:
             return "MPPS N-SET failed";
-        case pacs_error::mwl_query_failed:
-            return "MWL query failed";
         case pacs_error::storage_failed:
             return "DICOM storage failed";
         case pacs_error::invalid_sop_uid:
@@ -107,21 +105,6 @@ bool mpps_record::is_valid() const {
     if (status == "COMPLETED" && !end_datetime.has_value()) {
         return false;
     }
-
-    return true;
-}
-
-// =============================================================================
-// mwl_item Implementation
-// =============================================================================
-
-bool mwl_item::is_valid() const {
-    // Check required fields
-    if (accession_number.empty()) return false;
-    if (scheduled_procedure_step_id.empty()) return false;
-    if (patient_id.empty()) return false;
-    if (patient_name.empty()) return false;
-    if (modality.empty()) return false;
 
     return true;
 }
@@ -221,33 +204,6 @@ private:
 };
 
 // =============================================================================
-// Stub MWL Query Adapter
-// =============================================================================
-
-/**
- * @brief Stub implementation of MWL query adapter (standalone mode)
- *
- * Provides no-op implementations for testing and standalone usage.
- */
-class stub_mwl_query_adapter : public mwl_query_adapter {
-public:
-    std::expected<std::vector<mwl_item>, pacs_error> query_mwl(
-        const mwl_query_params& params) override {
-        // Stub: return empty result
-        return std::vector<mwl_item>{};
-    }
-
-    std::expected<mwl_item, pacs_error> get_mwl_item(
-        std::string_view accession_number) override {
-        if (accession_number.empty()) {
-            return std::unexpected(pacs_error::validation_failed);
-        }
-        // Stub: not found
-        return std::unexpected(pacs_error::not_found);
-    }
-};
-
-// =============================================================================
 // Stub Storage Adapter
 // =============================================================================
 
@@ -296,16 +252,11 @@ public:
     explicit stub_pacs_adapter(const pacs_config& config)
         : config_(config)
         , mpps_adapter_(std::make_shared<stub_mpps_adapter>())
-        , mwl_adapter_(std::make_shared<stub_mwl_query_adapter>())
         , storage_adapter_(std::make_shared<stub_storage_adapter>())
         , connected_(false) {}
 
     std::shared_ptr<mpps_adapter> get_mpps_adapter() override {
         return mpps_adapter_;
-    }
-
-    std::shared_ptr<mwl_query_adapter> get_mwl_adapter() override {
-        return mwl_adapter_;
     }
 
     std::shared_ptr<storage_adapter> get_storage_adapter() override {
@@ -335,7 +286,6 @@ public:
 private:
     pacs_config config_;
     std::shared_ptr<stub_mpps_adapter> mpps_adapter_;
-    std::shared_ptr<stub_mwl_query_adapter> mwl_adapter_;
     std::shared_ptr<stub_storage_adapter> storage_adapter_;
     bool connected_;
 };
@@ -349,7 +299,6 @@ private:
 #include <pacs/storage/index_database.hpp>
 #include <pacs/storage/instance_record.hpp>
 #include <pacs/storage/mpps_record.hpp>
-#include <pacs/storage/worklist_record.hpp>
 
 namespace {
 
@@ -533,61 +482,6 @@ to_pacs_mpps_query(const mpps_query_params& params) {
     return query;
 }
 
-// =============================================================================
-// MWL Conversion
-// =============================================================================
-
-mwl_item from_pacs_worklist_item(const pacs::storage::worklist_item& wl) {
-    mwl_item item;
-
-    item.accession_number = wl.accession_no;
-    item.scheduled_procedure_step_id = wl.step_id;
-    item.requested_procedure_id = wl.requested_proc_id;
-    item.scheduled_station_ae_title = wl.station_ae;
-    item.modality = wl.modality;
-    item.patient_id = wl.patient_id;
-    item.patient_name = wl.patient_name;
-    item.study_instance_uid = wl.study_uid;
-
-    if (!wl.scheduled_datetime.empty()) {
-        auto tp = parse_datetime_string(wl.scheduled_datetime);
-        if (tp) {
-            item.scheduled_datetime = *tp;
-        }
-    }
-
-    return item;
-}
-
-pacs::storage::worklist_query
-to_pacs_worklist_query(const mwl_query_params& params) {
-    pacs::storage::worklist_query query;
-
-    if (params.patient_id) {
-        query.patient_id = *params.patient_id;
-    }
-    if (params.accession_number) {
-        query.accession_no = *params.accession_number;
-    }
-    if (params.modality) {
-        query.modality = *params.modality;
-    }
-    if (params.scheduled_date) {
-        auto date_str = format_datetime_string(*params.scheduled_date);
-        // Use date portion only (YYYYMMDD)
-        query.scheduled_date_from = date_str.substr(0, 8);
-        query.scheduled_date_to = date_str.substr(0, 8);
-    }
-
-    query.include_all_status = false;
-
-    if (params.max_results > 0) {
-        query.limit = params.max_results;
-    }
-
-    return query;
-}
-
 }  // anonymous namespace
 
 // =============================================================================
@@ -678,70 +572,6 @@ public:
         }
 
         return from_pacs_mpps_record(result.value());
-    }
-
-private:
-    std::shared_ptr<pacs::storage::index_database> db_;
-};
-
-// =============================================================================
-// pacs_system MWL Query Adapter
-// =============================================================================
-
-/**
- * @brief MWL query adapter backed by pacs_system index_database
- *
- * Provides worklist query operations through pacs_system's index database.
- * For the full MWL adapter with add/update/delete, see mwl_adapter.cpp.
- */
-class pacs_system_mwl_query_adapter : public mwl_query_adapter {
-public:
-    explicit pacs_system_mwl_query_adapter(
-        std::shared_ptr<pacs::storage::index_database> db)
-        : db_(std::move(db)) {}
-
-    std::expected<std::vector<mwl_item>, pacs_error>
-    query_mwl(const mwl_query_params& params) override {
-        if (!db_) {
-            return std::unexpected(pacs_error::connection_failed);
-        }
-
-        auto wl_query = to_pacs_worklist_query(params);
-        auto result = db_->query_worklist(wl_query);
-        if (result.is_err()) {
-            return std::unexpected(pacs_error::mwl_query_failed);
-        }
-
-        std::vector<mwl_item> items;
-        items.reserve(result.value().size());
-        for (const auto& wl : result.value()) {
-            items.push_back(from_pacs_worklist_item(wl));
-        }
-
-        return items;
-    }
-
-    std::expected<mwl_item, pacs_error>
-    get_mwl_item(std::string_view accession_number) override {
-        if (accession_number.empty()) {
-            return std::unexpected(pacs_error::validation_failed);
-        }
-        if (!db_) {
-            return std::unexpected(pacs_error::connection_failed);
-        }
-
-        // Query by accession number with limit 1
-        pacs::storage::worklist_query query;
-        query.accession_no = std::string(accession_number);
-        query.include_all_status = true;
-        query.limit = 1;
-
-        auto result = db_->query_worklist(query);
-        if (result.is_err() || result.value().empty()) {
-            return std::unexpected(pacs_error::not_found);
-        }
-
-        return from_pacs_worklist_item(result.value()[0]);
     }
 
 private:
@@ -843,16 +673,11 @@ public:
         std::shared_ptr<pacs::storage::index_database> db)
         : db_(std::move(db))
         , mpps_adapter_(std::make_shared<pacs_system_mpps_adapter>(db_))
-        , mwl_adapter_(std::make_shared<pacs_system_mwl_query_adapter>(db_))
         , storage_adapter_(std::make_shared<pacs_system_storage_adapter>(db_))
         , connected_(false) {}
 
     std::shared_ptr<mpps_adapter> get_mpps_adapter() override {
         return mpps_adapter_;
-    }
-
-    std::shared_ptr<mwl_query_adapter> get_mwl_adapter() override {
-        return mwl_adapter_;
     }
 
     std::shared_ptr<storage_adapter> get_storage_adapter() override {
@@ -882,7 +707,6 @@ public:
 private:
     std::shared_ptr<pacs::storage::index_database> db_;
     std::shared_ptr<pacs_system_mpps_adapter> mpps_adapter_;
-    std::shared_ptr<pacs_system_mwl_query_adapter> mwl_adapter_;
     std::shared_ptr<pacs_system_storage_adapter> storage_adapter_;
     bool connected_;
 };

--- a/tests/integration/standalone_mode_test.cpp
+++ b/tests/integration/standalone_mode_test.cpp
@@ -336,19 +336,6 @@ TEST_F(StandalonePacsTest, MppsUpdateValidRecord) {
     EXPECT_TRUE(update.has_value());
 }
 
-TEST_F(StandalonePacsTest, MwlQuery) {
-    auto connect = adapter_->connect();
-    ASSERT_TRUE(connect.has_value());
-
-    auto mwl = adapter_->get_mwl_adapter();
-    ASSERT_NE(mwl, nullptr);
-
-    mwl_query_params params;
-    params.max_results = 10;
-    auto result = mwl->query_mwl(params);
-    EXPECT_TRUE(result.has_value());
-}
-
 TEST_F(StandalonePacsTest, StorageStubBehavior) {
     auto connect = adapter_->connect();
     ASSERT_TRUE(connect.has_value());
@@ -393,7 +380,6 @@ TEST_F(StandalonePacsTest, SubAdaptersAvailable) {
     ASSERT_TRUE(connect.has_value());
 
     EXPECT_NE(adapter_->get_mpps_adapter(), nullptr);
-    EXPECT_NE(adapter_->get_mwl_adapter(), nullptr);
     EXPECT_NE(adapter_->get_storage_adapter(), nullptr);
 }
 

--- a/tests/integration/system_integration_test.cpp
+++ b/tests/integration/system_integration_test.cpp
@@ -496,21 +496,6 @@ TEST_F(AdapterErrorTest, MppsRecordValidation) {
     EXPECT_TRUE(record.is_valid());
 }
 
-TEST_F(AdapterErrorTest, MwlItemValidation) {
-    mwl_item item;
-    EXPECT_FALSE(item.is_valid());
-
-    // All required fields: accession_number, scheduled_procedure_step_id,
-    // patient_id, patient_name, modality
-    item.accession_number = "ACC001";
-    item.scheduled_procedure_step_id = "SPS001";
-    item.patient_id = "PAT001";
-    item.patient_name = "DOE^JOHN";
-    item.modality = "CT";
-    item.scheduled_datetime = std::chrono::system_clock::now();
-    EXPECT_TRUE(item.is_valid());
-}
-
 // =============================================================================
 // Conditional System Integration Tests
 // =============================================================================

--- a/tests/pacs_adapter_test.cpp
+++ b/tests/pacs_adapter_test.cpp
@@ -71,7 +71,6 @@ TEST(PacsErrorTest, ErrorCodeConversion) {
     EXPECT_EQ(to_error_code(pacs_error::validation_failed), -858);
     EXPECT_EQ(to_error_code(pacs_error::mpps_create_failed), -859);
     EXPECT_EQ(to_error_code(pacs_error::mpps_update_failed), -860);
-    EXPECT_EQ(to_error_code(pacs_error::mwl_query_failed), -861);
     EXPECT_EQ(to_error_code(pacs_error::storage_failed), -862);
     EXPECT_EQ(to_error_code(pacs_error::invalid_sop_uid), -863);
 }
@@ -80,7 +79,6 @@ TEST(PacsErrorTest, ErrorMessages) {
     EXPECT_EQ(to_string(pacs_error::connection_failed), "Connection to PACS server failed");
     EXPECT_EQ(to_string(pacs_error::query_failed), "Query execution failed");
     EXPECT_EQ(to_string(pacs_error::mpps_create_failed), "MPPS N-CREATE failed");
-    EXPECT_EQ(to_string(pacs_error::mwl_query_failed), "MWL query failed");
 }
 
 // =============================================================================
@@ -203,33 +201,6 @@ TEST(MppsRecordTest, ValidStatuses) {
 
     record.status = "DISCONTINUED";
     EXPECT_TRUE(record.is_valid());
-}
-
-// =============================================================================
-// MWL Item Tests
-// =============================================================================
-
-TEST(MwlItemTest, ValidItem) {
-    mwl_item item;
-    item.accession_number = "ACC123";
-    item.scheduled_procedure_step_id = "SPS001";
-    item.patient_id = "PAT123";
-    item.patient_name = "Test^Patient";
-    item.modality = "CT";
-
-    EXPECT_TRUE(item.is_valid());
-}
-
-TEST(MwlItemTest, MissingRequiredFields) {
-    mwl_item item;
-
-    // Missing all required fields
-    EXPECT_FALSE(item.is_valid());
-
-    // Missing accession_number
-    item.scheduled_procedure_step_id = "SPS001";
-    item.patient_id = "PAT123";
-    EXPECT_FALSE(item.is_valid());
 }
 
 // =============================================================================
@@ -504,53 +475,6 @@ TEST_F(PacsAdapterTest, GetNonExistentMpps) {
     auto result = mpps->get_mpps("999.999.999.999");
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), pacs_error::not_found);
-}
-
-// =============================================================================
-// MWL Adapter Tests
-// =============================================================================
-
-TEST_F(PacsAdapterTest, GetMwlAdapter) {
-    auto mwl = adapter_->get_mwl_adapter();
-    ASSERT_NE(mwl, nullptr);
-}
-
-TEST_F(PacsAdapterTest, QueryMwl) {
-    ASSERT_TRUE(adapter_->connect().has_value());
-
-    auto mwl = adapter_->get_mwl_adapter();
-    ASSERT_NE(mwl, nullptr);
-
-    mwl_query_params params;
-    params.max_results = 100;
-
-    auto result = mwl->query_mwl(params);
-    EXPECT_TRUE(result.has_value());
-}
-
-TEST_F(PacsAdapterTest, QueryMwlByPatientId) {
-    ASSERT_TRUE(adapter_->connect().has_value());
-
-    auto mwl = adapter_->get_mwl_adapter();
-    ASSERT_NE(mwl, nullptr);
-
-    mwl_query_params params;
-    params.patient_id = "PAT123";
-    params.max_results = 100;
-
-    auto result = mwl->query_mwl(params);
-    EXPECT_TRUE(result.has_value());
-}
-
-TEST_F(PacsAdapterTest, GetMwlItem) {
-    ASSERT_TRUE(adapter_->connect().has_value());
-
-    auto mwl = adapter_->get_mwl_adapter();
-    ASSERT_NE(mwl, nullptr);
-
-    auto result = mwl->get_mwl_item("ACC123");
-    // May return not_found if no item exists
-    EXPECT_TRUE(result.has_value() || result.error() == pacs_error::not_found);
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #365

## Summary
- Remove dead MWL code from `pacs_adapter.h` that was superseded by the full CRUD `mwl_adapter` in `mwl_adapter.h`
- The actual MWL data flow bypasses `pacs_adapter` entirely: `mwl_client` -> `integration::mwl_adapter`
- Reduces `pacs_adapter.h` from ~547 lines to ~439 lines (~20% reduction)

## Changes

### Removed from `pacs_adapter.h`
| Component | Reason |
|-----------|--------|
| `struct mwl_item` | Consumers use `mapping::mwl_item` (nested struct) |
| `struct mwl_query_params` | Consumers use `mwl_query_filter` from `mwl_adapter.h` |
| `class mwl_query_adapter` | Read-only; consumers use full CRUD `mwl_adapter` |
| `pacs_adapter::get_mwl_adapter()` | No callers in production code |
| `pacs_error::mwl_query_failed` | Only used by removed MWL adapter |

### Removed from `pacs_adapter.cpp`
- `stub_mwl_query_adapter` class
- `pacs_system_mwl_query_adapter` class
- MWL conversion helpers (`from_pacs_worklist_item`, `to_pacs_worklist_query`)
- MWL adapter members from `stub_pacs_adapter` and `pacs_system_adapter`
- `worklist_record.hpp` include (no longer needed)

### Updated
- `benchmarks/baseline_benchmark.cpp`: Use `create_mwl_adapter()` + `mwl_query_filter` for MWL latency benchmark
- Tests: Remove MWL adapter tests that tested removed interfaces
- Documentation: Update `integration_guide.md` and `error-codes.md`

## Test Plan
- [x] Build succeeds (85/85 targets)
- [x] `pacs_adapter_test` passes (33/33 tests)
- [x] `standalone_mode_test` passes
- [x] `mwl_client_test` passes
- [x] `system_integration_test` - 1 pre-existing failure (`MppsUpdateWithDatabaseSync`) unrelated to this change