### PR TITLE
feat(integration): add shared index_database factory overloads (#366)

### DIFF
--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -85,6 +85,23 @@ filter.patient_id = "PAT001";
 auto items = mwl->query_items(filter);
 ```
 
+### Shared Database (Full Build Only)
+
+```cpp
+// Share a single index_database across PACS and MWL adapters
+#include "pacs/bridge/integration/pacs_adapter.h"
+#include "pacs/bridge/integration/mwl_adapter.h"
+#include <pacs/storage/index_database.hpp>
+
+auto db_result = pacs::storage::index_database::open("pacs_bridge.db");
+auto db = std::shared_ptr<pacs::storage::index_database>(
+    db_result.value().release());
+
+auto pacs = create_pacs_adapter(pacs_config{}, db);
+auto mwl  = create_mwl_adapter(db);
+// Both adapters share the same database connection
+```
+
 ### Executor Adapter (Full Build Only)
 
 ```cpp

--- a/include/pacs/bridge/integration/mwl_adapter.h
+++ b/include/pacs/bridge/integration/mwl_adapter.h
@@ -25,6 +25,13 @@
 #include <string_view>
 #include <vector>
 
+// Forward declaration for shared database support
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+namespace pacs::storage {
+class index_database;
+}
+#endif
+
 namespace pacs::bridge::integration {
 
 // =============================================================================
@@ -249,15 +256,31 @@ public:
 /**
  * @brief Create appropriate MWL adapter based on build configuration
  *
- * Returns:
- * - memory_mwl_adapter if PACS_BRIDGE_STANDALONE_BUILD is defined
- * - pacs_mwl_adapter if PACS_BRIDGE_HAS_PACS_SYSTEM is defined
+ * Opens its own database connection based on database_path.
+ * For sharing a database instance with other adapters (e.g., pacs_adapter),
+ * use the overload that accepts a shared_ptr<index_database>.
  *
  * @param database_path Path to pacs_system database (used only for pacs_mwl_adapter)
  * @return Shared pointer to mwl_adapter implementation
  */
 [[nodiscard]] std::shared_ptr<mwl_adapter>
 create_mwl_adapter(const std::string& database_path = "");
+
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+/**
+ * @brief Create MWL adapter with a pre-opened shared database
+ *
+ * Allows sharing the same index_database instance across multiple
+ * adapters (e.g., pacs_adapter and mwl_adapter) to avoid duplicate
+ * connections to the same SQLite file.
+ *
+ * @param db Shared database instance (must not be nullptr and must be open)
+ * @return Shared pointer to mwl_adapter backed by the given database,
+ *         or memory_mwl_adapter if db is null/closed
+ */
+[[nodiscard]] std::shared_ptr<mwl_adapter>
+create_mwl_adapter(std::shared_ptr<pacs::storage::index_database> db);
+#endif
 
 }  // namespace pacs::bridge::integration
 

--- a/include/pacs/bridge/integration/pacs_adapter.h
+++ b/include/pacs/bridge/integration/pacs_adapter.h
@@ -26,6 +26,13 @@
 #include <string_view>
 #include <vector>
 
+// Forward declaration for shared database support
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+namespace pacs::storage {
+class index_database;
+}
+#endif
+
 namespace pacs::bridge::integration {
 
 // =============================================================================
@@ -425,13 +432,34 @@ struct pacs_config {
 // =============================================================================
 
 /**
- * @brief Create PACS adapter (standalone mode with stub implementation)
+ * @brief Create PACS adapter
+ *
+ * Opens its own database connection based on config.database_path.
+ * For sharing a database instance with other adapters (e.g., mwl_adapter),
+ * use the overload that accepts a shared_ptr<index_database>.
  *
  * @param config PACS configuration
  * @return Shared pointer to PACS adapter
  */
 [[nodiscard]] std::shared_ptr<pacs_adapter>
 create_pacs_adapter(const pacs_config& config);
+
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+/**
+ * @brief Create PACS adapter with a pre-opened shared database
+ *
+ * Allows sharing the same index_database instance across multiple
+ * adapters (e.g., pacs_adapter and mwl_adapter) to avoid duplicate
+ * connections to the same SQLite file.
+ *
+ * @param config PACS configuration
+ * @param db Shared database instance (must not be nullptr)
+ * @return Shared pointer to PACS adapter backed by the given database
+ */
+[[nodiscard]] std::shared_ptr<pacs_adapter>
+create_pacs_adapter(const pacs_config& config,
+                    std::shared_ptr<pacs::storage::index_database> db);
+#endif
 
 }  // namespace pacs::bridge::integration
 

--- a/src/integration/mwl_adapter.cpp
+++ b/src/integration/mwl_adapter.cpp
@@ -604,8 +604,12 @@ public:
                       << "' - adapter will be non-functional" << std::endl;
             return;
         }
-        db_ = std::move(db_result.value());
+        db_ = std::shared_ptr<pacs::storage::index_database>(
+            db_result.value().release());
     }
+
+    explicit pacs_mwl_adapter(std::shared_ptr<pacs::storage::index_database> db)
+        : db_(std::move(db)) {}
 
     ~pacs_mwl_adapter() override = default;
 
@@ -800,7 +804,7 @@ public:
     }
 
 private:
-    std::unique_ptr<pacs::storage::index_database> db_;
+    std::shared_ptr<pacs::storage::index_database> db_;
 };
 
 #endif  // PACS_BRIDGE_HAS_PACS_SYSTEM
@@ -828,5 +832,17 @@ create_mwl_adapter(const std::string& database_path) {
     // Fallback: in-memory adapter for testing and standalone mode
     return std::make_shared<memory_mwl_adapter>();
 }
+
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+std::shared_ptr<mwl_adapter>
+create_mwl_adapter(std::shared_ptr<pacs::storage::index_database> db) {
+    if (db && db->is_open()) {
+        return std::make_shared<pacs_mwl_adapter>(std::move(db));
+    }
+    std::cerr << "create_mwl_adapter: shared database unavailable, "
+                 "falling back to in-memory adapter" << std::endl;
+    return std::make_shared<memory_mwl_adapter>();
+}
+#endif
 
 }  // namespace pacs::bridge::integration

--- a/src/integration/pacs_adapter.cpp
+++ b/src/integration/pacs_adapter.cpp
@@ -736,4 +736,16 @@ std::shared_ptr<pacs_adapter> create_pacs_adapter(const pacs_config& config) {
     return std::make_shared<stub_pacs_adapter>(config);
 }
 
+#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
+std::shared_ptr<pacs_adapter>
+create_pacs_adapter(const pacs_config& config,
+                    std::shared_ptr<pacs::storage::index_database> db) {
+    if (db && db->is_open()) {
+        return std::make_shared<pacs_system_adapter>(std::move(db));
+    }
+    // Fallback to stub if database is null or not open
+    return std::make_shared<stub_pacs_adapter>(config);
+}
+#endif
+
 }  // namespace pacs::bridge::integration

--- a/tests/integration/standalone_mode_test.cpp
+++ b/tests/integration/standalone_mode_test.cpp
@@ -537,6 +537,34 @@ TEST_F(MwlAdapterFactoryTest, UpdateItemUpdatesAllFields) {
               "CT1");  // Unchanged
 }
 
+TEST_F(MwlAdapterFactoryTest, FactoryOverloadsAreBackwardCompatible) {
+    // Existing factory with empty path should still work
+    auto adapter1 = create_mwl_adapter("");
+    ASSERT_NE(adapter1, nullptr);
+    EXPECT_TRUE(adapter1->is_available());
+
+    // Existing factory with default parameter should still work
+    auto adapter2 = create_mwl_adapter();
+    ASSERT_NE(adapter2, nullptr);
+    EXPECT_TRUE(adapter2->is_available());
+
+    // Both should be functional memory adapters
+    mapping::mwl_item item;
+    item.imaging_service_request.accession_number = "ACC_COMPAT_001";
+    item.patient.patient_id = "PAT001";
+
+    EXPECT_TRUE(adapter1->add_item(item).has_value());
+    EXPECT_TRUE(adapter1->exists("ACC_COMPAT_001"));
+
+    item.imaging_service_request.accession_number = "ACC_COMPAT_002";
+    EXPECT_TRUE(adapter2->add_item(item).has_value());
+    EXPECT_TRUE(adapter2->exists("ACC_COMPAT_002"));
+
+    // Each adapter should have its own independent storage
+    EXPECT_FALSE(adapter1->exists("ACC_COMPAT_002"));
+    EXPECT_FALSE(adapter2->exists("ACC_COMPAT_001"));
+}
+
 // =============================================================================
 // Cross-Adapter Resource Cleanup Tests
 // =============================================================================

--- a/tests/pacs_adapter_test.cpp
+++ b/tests/pacs_adapter_test.cpp
@@ -204,6 +204,30 @@ TEST(MppsRecordTest, ValidStatuses) {
 }
 
 // =============================================================================
+// Factory Backward Compatibility Tests
+// =============================================================================
+
+TEST(PacsFactoryTest, CreateWithDefaultConfig) {
+    auto adapter = create_pacs_adapter(pacs_config{});
+    ASSERT_NE(adapter, nullptr);
+    // Stub adapter starts disconnected
+    EXPECT_FALSE(adapter->is_connected());
+    // Can connect and use
+    EXPECT_TRUE(adapter->connect().has_value());
+    EXPECT_NE(adapter->get_mpps_adapter(), nullptr);
+    EXPECT_NE(adapter->get_storage_adapter(), nullptr);
+}
+
+TEST(PacsFactoryTest, CreateWithNonexistentDbPath) {
+    pacs_config config;
+    config.database_path = "/nonexistent/path/to/db.sqlite";
+    auto adapter = create_pacs_adapter(config);
+    ASSERT_NE(adapter, nullptr);
+    // Falls back to stub adapter
+    EXPECT_TRUE(adapter->connect().has_value());
+}
+
+// =============================================================================
 // PACS Adapter Connection Tests
 // =============================================================================
 


### PR DESCRIPTION
Closes #366

## Summary
- Add factory overloads accepting `shared_ptr<index_database>` for both `create_pacs_adapter()` and `create_mwl_adapter()`, enabling a single database instance to be shared across adapters
- Forward-declare `pacs::storage::index_database` in public headers under `#ifdef PACS_BRIDGE_HAS_PACS_SYSTEM` guards
- Change `pacs_mwl_adapter::db_` from `unique_ptr` to `shared_ptr` to support shared ownership
- Existing path-based factory overloads remain unchanged for backward compatibility

## Test Plan
- [x] Added `PacsFactoryTest` suite (2 tests) verifying stub adapter creation
- [x] Added `FactoryOverloadsAreBackwardCompatible` test verifying independent storage across adapter instances
- [x] All existing tests pass: `pacs_adapter_test` (35/35), `standalone_mode_test` (30/30), `mwl_client_test` (37/37)
- [x] Full build succeeds with standalone mode (85 targets)