### PR TITLE
chore(vcpkg): migrate to vcpkg-configuration.json and add ecosystem overrides

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry.git",
+      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+      "packages": ["kcenon-*"]
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -40,6 +40,9 @@
       ]
     }
   },
-  "overrides": [],
-  "builtin-baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6"
+  "overrides": [
+    { "name": "gtest", "version": "1.17.0" },
+    { "name": "benchmark", "version": "1.9.5" },
+    { "name": "spdlog", "version": "1.15.3" }
+  ]
 }


### PR DESCRIPTION
## What

Migrate pacs_bridge from the legacy `builtin-baseline` field in `vcpkg.json` to the ecosystem-standard `vcpkg-configuration.json` pattern, and add shared version overrides.

### Changes

| File | Change |
|------|--------|
| `vcpkg-configuration.json` | **Created** — ecosystem baselines and custom registry |
| `vcpkg.json` | Removed `builtin-baseline`, added overrides |

### Override Versions Added

| Package | Version | Matches Core Ecosystem |
|---------|---------|:---------------------:|
| gtest | 1.17.0 | Yes |
| benchmark | 1.9.5 | Yes |
| spdlog | 1.15.3 | Yes |

## Why

- Previous `builtin-baseline` (`a42af01b...`) diverged from ecosystem standard (`d90a9b15...`)
- Missing custom registry prevented consuming `kcenon-*` packages via vcpkg
- No overrides meant shared packages could resolve to different versions than core projects

## Where

- `vcpkg.json` — removed `builtin-baseline`, added `overrides`
- `vcpkg-configuration.json` — new file with ecosystem baselines

## How

Replaced `builtin-baseline` with `vcpkg-configuration.json` (the newer vcpkg pattern). Added `kcenon/vcpkg-registry` as a custom registry for `kcenon-*` packages. Pinned shared dependencies to ecosystem-standard versions.

Closes #374
Part of kcenon/common_system#509