### PR TITLE
chore(vcpkg): add openssl override for tls feature consistency

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -43,6 +43,7 @@
   "overrides": [
     { "name": "gtest", "version": "1.17.0" },
     { "name": "benchmark", "version": "1.9.5" },
-    { "name": "spdlog", "version": "1.15.3" }
+    { "name": "spdlog", "version": "1.15.3" },
+    { "name": "openssl", "version": "3.4.1" }
   ]
 }


### PR DESCRIPTION
## What
Add `openssl` version override (3.4.1) to `vcpkg.json` overrides array.

## Why
When the `tls` feature is enabled, openssl resolves from the baseline without a pinned version. Core ecosystem projects pin openssl to 3.4.1 — this aligns pacs_bridge with the standard.

## How
Added one entry to the `overrides` array: `{ "name": "openssl", "version": "3.4.1" }`.

Closes #376