### PR TITLE
feat(build): add kcenon ecosystem dependencies to vcpkg.json features

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,95 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default (Release, vcpkg)",
+      "description": "Release build with vcpkg ecosystem features enabled",
+      "binaryDir": "${sourceDir}/build-default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_MANIFEST_FEATURES": "ecosystem;monitoring;pacs;tls"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug (vcpkg)",
+      "description": "Debug build with vcpkg toolchain",
+      "binaryDir": "${sourceDir}/build-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_MANIFEST_FEATURES": "ecosystem;monitoring;pacs;tls;tests"
+      }
+    },
+    {
+      "name": "standalone",
+      "displayName": "Standalone (no kcenon deps)",
+      "description": "Release build without external kcenon dependencies",
+      "binaryDir": "${sourceDir}/build-standalone",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BRIDGE_STANDALONE_BUILD": "ON"
+      }
+    },
+    {
+      "name": "dev-fetchcontent",
+      "displayName": "Dev FetchContent (Debug)",
+      "description": "Debug build using FetchContent for kcenon deps (no vcpkg)",
+      "binaryDir": "${sourceDir}/build-dev-fetchcontent",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "BRIDGE_STANDALONE_BUILD": "OFF",
+        "PACS_BRIDGE_USE_FETCHCONTENT": "ON",
+        "BRIDGE_BUILD_TESTS": "ON"
+      }
+    },
+    {
+      "name": "ci",
+      "displayName": "CI (RelWithDebInfo, full features)",
+      "description": "CI build with full features and pedantic warnings",
+      "binaryDir": "${sourceDir}/build-ci",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_MANIFEST_FEATURES": "ecosystem;monitoring;pacs;database;tls;tests",
+        "BRIDGE_BUILD_TESTS": "ON",
+        "CMAKE_CXX_FLAGS": "-Wall -Wextra -Wpedantic -Werror"
+      }
+    },
+    {
+      "name": "asan",
+      "displayName": "AddressSanitizer (Debug)",
+      "description": "Debug build with AddressSanitizer enabled",
+      "binaryDir": "${sourceDir}/build-asan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_MANIFEST_FEATURES": "ecosystem;monitoring;pacs;tests",
+        "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address"
+      }
+    },
+    {
+      "name": "tsan",
+      "displayName": "ThreadSanitizer (Debug)",
+      "description": "Debug build with ThreadSanitizer enabled",
+      "binaryDir": "${sourceDir}/build-tsan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_MANIFEST_FEATURES": "ecosystem;monitoring;pacs;tests",
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=thread"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -235,20 +235,65 @@ Module partitions:
 
 ### vcpkg Integration
 
-The project uses vcpkg manifest mode (`vcpkg.json`) for managing standard third-party
-dependencies (OpenSSL, GTest, fmt, spdlog, etc.). The kcenon ecosystem packages are
-managed via CMake FetchContent.
+The project uses vcpkg manifest mode (`vcpkg.json`) for managing both standard third-party
+dependencies (OpenSSL, GTest, fmt, spdlog, etc.) and kcenon ecosystem packages via a
+[custom vcpkg registry](https://github.com/kcenon/vcpkg-registry).
+
+#### Prerequisites
+
+- [vcpkg](https://github.com/microsoft/vcpkg) installed
+- `VCPKG_ROOT` environment variable set to your vcpkg installation path
+
+#### Using CMake Presets (Recommended)
+
+CMakePresets.json provides pre-configured build profiles:
 
 ```bash
-# With vcpkg (recommended for cross-platform builds)
-cmake -B build -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
+# Default release build with vcpkg ecosystem features
+cmake --preset default
+cmake --build --preset default
+
+# Debug build with tests
+cmake --preset debug
+cmake --build --preset debug
+```
+
+#### Available Presets
+
+| Preset | Description |
+|--------|-------------|
+| `default` | Release build with vcpkg ecosystem features (ecosystem, monitoring, pacs, tls) |
+| `debug` | Debug build with vcpkg toolchain and tests enabled |
+| `standalone` | Release build without external kcenon dependencies (no vcpkg required) |
+| `dev-fetchcontent` | Debug build using FetchContent for kcenon deps (preserves existing dev workflow) |
+| `ci` | RelWithDebInfo with full features and pedantic warnings |
+| `asan` | Debug build with AddressSanitizer enabled |
+| `tsan` | Debug build with ThreadSanitizer enabled |
+
+#### Manual vcpkg Configuration
+
+```bash
+# With explicit toolchain file
+cmake -B build -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
 cmake --build build
 
-# Or using VCPKG_ROOT environment variable
-export VCPKG_ROOT=/path/to/vcpkg
-cmake -B build
+# Enable specific vcpkg features
+cmake -B build \
+  -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+  -DVCPKG_MANIFEST_FEATURES="ecosystem;monitoring;pacs;tls"
 cmake --build build
 ```
+
+#### vcpkg Manifest Features
+
+| Feature | Description |
+|---------|-------------|
+| `ecosystem` | Enable kcenon ecosystem dependencies (common, thread, container systems) |
+| `monitoring` | Enable runtime monitoring integration (monitoring_system) |
+| `pacs` | Enable PACS/DICOM system integration (pacs_system) |
+| `database` | Enable database persistence support (database_system) |
+| `tls` | Enable TLS support (OpenSSL) |
+| `tests` | Build with test dependencies (GTest) |
 
 ## Configuration
 

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -47,16 +47,41 @@ Thank you for your interest in contributing to PACS Bridge! This document provid
 | C++ Compiler | GCC 13+, Clang 14+, MSVC 2022+ | C++23 support required |
 | CMake | 3.20+ | Build system |
 | Git | Latest | Version control |
-| vcpkg | Latest | Package management |
+| vcpkg | Latest | Package management (optional for standalone builds) |
 
 ### Clone and Build
+
+#### Using CMake Presets (Recommended)
 
 ```bash
 # Clone the repository
 git clone https://github.com/kcenon/pacs_bridge.git
 cd pacs_bridge
 
-# Clone dependencies (optional for full build)
+# Option 1: Debug build with vcpkg (requires VCPKG_ROOT set)
+cmake --preset debug
+cmake --build --preset debug
+
+# Option 2: FetchContent build (no vcpkg, clones kcenon deps via Git)
+cmake --preset dev-fetchcontent
+cmake --build --preset dev-fetchcontent
+
+# Option 3: Standalone build (no external kcenon dependencies)
+cmake --preset standalone
+cmake --build --preset standalone
+
+# Run tests
+ctest --test-dir build-debug --output-on-failure
+```
+
+#### Using Manual CMake Configuration
+
+```bash
+# Clone the repository
+git clone https://github.com/kcenon/pacs_bridge.git
+cd pacs_bridge
+
+# Clone dependencies (optional for full build without vcpkg)
 cd ..
 git clone https://github.com/kcenon/common_system.git
 git clone https://github.com/kcenon/thread_system.git

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -153,7 +153,7 @@ cmake --preset default
 cmake --build --preset default
 ```
 
-See [CMakePresets.json](../../CMakePresets.json) for all available presets
+See [`CMakePresets.json`](https://github.com/kcenon/pacs_bridge/blob/main/CMakePresets.json) for all available presets
 (`default`, `debug`, `standalone`, `dev-fetchcontent`, `ci`, `asan`, `tsan`).
 
 #### Option C: Docker Deployment

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -127,7 +127,7 @@ PACS Bridge is a C++20 integration gateway that connects Hospital Information Sy
 
 ### Step 1: Install PACS Bridge
 
-#### Option A: Build from Source
+#### Option A: Build from Source (Standalone)
 
 ```bash
 # Clone the repository
@@ -135,11 +135,28 @@ git clone https://github.com/kcenon/pacs_bridge.git
 cd pacs_bridge
 
 # Build in standalone mode (no external dependencies)
-cmake -B build -DBRIDGE_STANDALONE_BUILD=ON
-cmake --build build
+cmake --preset standalone
+cmake --build --preset standalone
 ```
 
-#### Option B: Docker Deployment
+#### Option B: Build with vcpkg (Full Features)
+
+Requires [vcpkg](https://github.com/microsoft/vcpkg) installed and `VCPKG_ROOT` set.
+
+```bash
+# Clone the repository
+git clone https://github.com/kcenon/pacs_bridge.git
+cd pacs_bridge
+
+# Build with vcpkg ecosystem features using CMake Presets
+cmake --preset default
+cmake --build --preset default
+```
+
+See [CMakePresets.json](../../CMakePresets.json) for all available presets
+(`default`, `debug`, `standalone`, `dev-fetchcontent`, `ci`, `asan`, `tsan`).
+
+#### Option C: Docker Deployment
 
 ```bash
 # Pull the latest image

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+      "baseline": "afdfab7fbc642bd71fd4764c970a91334794021c",
       "packages": ["kcenon-*"]
     }
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,32 @@
     }
   ],
   "features": {
+    "ecosystem": {
+      "description": "Enable kcenon ecosystem dependencies (requires vcpkg registry)",
+      "dependencies": [
+        "kcenon-common-system",
+        "kcenon-thread-system",
+        "kcenon-container-system"
+      ]
+    },
+    "monitoring": {
+      "description": "Enable runtime monitoring integration",
+      "dependencies": [
+        "kcenon-monitoring-system"
+      ]
+    },
+    "pacs": {
+      "description": "Enable PACS/DICOM system integration",
+      "dependencies": [
+        "kcenon-pacs-system"
+      ]
+    },
+    "database": {
+      "description": "Enable database persistence support",
+      "dependencies": [
+        "kcenon-database-system"
+      ]
+    },
     "tests": {
       "description": "Build with test dependencies",
       "dependencies": [


### PR DESCRIPTION
## Summary

- Add kcenon ecosystem packages as vcpkg.json feature dependencies (ecosystem, monitoring, pacs, database)
- Create `CMakePresets.json` with 7 build presets (default, debug, standalone, dev-fetchcontent, ci, asan, tsan)
- Update kcenon registry baseline to latest (`afdfab7f`)
- Update documentation (README, getting-started, contributing) with vcpkg build instructions

Aligns pacs_bridge with the vcpkg patterns established in messaging_system.

## Test plan
- [ ] `cmake --preset default` configures successfully with vcpkg
- [ ] `cmake --preset standalone` works without kcenon dependencies
- [ ] `cmake --preset dev-fetchcontent` preserves existing FetchContent workflow
- [ ] All existing tests pass
- [ ] CI pipeline succeeds

Closes #378