### PR TITLE
refactor: update pacs_system include paths to kcenon/pacs/*.h

### DIFF
--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -91,7 +91,7 @@ auto items = mwl->query_items(filter);
 // Share a single index_database across PACS and MWL adapters
 #include "pacs/bridge/integration/pacs_adapter.h"
 #include "pacs/bridge/integration/mwl_adapter.h"
-#include <pacs/storage/index_database.hpp>
+#include <kcenon/pacs/storage/index_database.h>
 
 auto db_result = pacs::storage::index_database::open("pacs_bridge.db");
 auto db = std::shared_ptr<pacs::storage::index_database>(

--- a/src/integration/mwl_adapter.cpp
+++ b/src/integration/mwl_adapter.cpp
@@ -18,8 +18,8 @@
 #include <vector>
 
 #ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
-#include <pacs/storage/index_database.hpp>
-#include <pacs/storage/worklist_record.hpp>
+#include <kcenon/pacs/storage/index_database.h>
+#include <kcenon/pacs/storage/worklist_record.h>
 #endif
 
 namespace pacs::bridge::integration {

--- a/src/integration/pacs_adapter.cpp
+++ b/src/integration/pacs_adapter.cpp
@@ -296,9 +296,9 @@ private:
 
 #ifdef PACS_BRIDGE_HAS_PACS_SYSTEM
 
-#include <pacs/storage/index_database.hpp>
-#include <pacs/storage/instance_record.hpp>
-#include <pacs/storage/mpps_record.hpp>
+#include <kcenon/pacs/storage/index_database.h>
+#include <kcenon/pacs/storage/instance_record.h>
+#include <kcenon/pacs/storage/mpps_record.h>
 
 namespace {
 


### PR DESCRIPTION
## Summary

Update all pacs_system include references to use the new standardized paths after pacs_system moved headers from `include/pacs/` to `include/kcenon/pacs/` and renamed `.hpp` to `.h` (kcenon/pacs_system#1053).

## Changes

- `src/integration/pacs_adapter.cpp`: Updated 3 includes (`index_database`, `instance_record`, `mpps_record`)
- `src/integration/mwl_adapter.cpp`: Updated 2 includes (`index_database`, `worklist_record`)
- `docs/integration_guide.md`: Updated 1 code example

All changes follow the pattern: `<pacs/storage/*.hpp>` -> `<kcenon/pacs/storage/*.h>`

## Related Issues

Closes #380

## Test Plan

- [ ] Build passes with updated pacs_system (FetchContent pulls latest main)
- [ ] All existing tests pass
- [ ] No references to old `pacs/*.hpp` paths remain